### PR TITLE
fix: デバッグファイルを除外するよう.gitignoreを更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,9 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Debug and log files
+output.txt
+*.log
+debug/
+logs/


### PR DESCRIPTION
- output.txtおよびログファイルを除外
- debug/およびlogs/ディレクトリを除外
- デバッグログが誤ってコミットされないよう対策