### PR TITLE
fix: .gitignoreの重複エントリを整理してデバッグファイル除外を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 
+# Debug and log files
+output.txt
+debug/
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 


### PR DESCRIPTION
- output.txtとdebug/ディレクトリを除外対象に追加
- ログファイル関連の設定を整理
- 重複エントリの問題を解決