### PR TITLE
fix: ページタイトルを「カレーログ」から「セカカレ」に変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,21 +3,21 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>カレーログ - あなたのカレー体験を記録しよう</title>
+    <title>セカカレ - あなたのカレー体験を記録しよう</title>
     <meta name="description" content="食べたカレーを地図上に記録して、あなただけのカレーマップを作成。全国のカレー店を発見して、カレー巡りを楽しもう！">
     <meta name="keywords" content="カレー,グルメ,地図,ログ,記録,レストラン">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://your-domain.com/">
-    <meta property="og:title" content="カレーログ - あなたのカレー体験を記録しよう">
+    <meta property="og:title" content="セカカレ - あなたのカレー体験を記録しよう">
     <meta property="og:description" content="食べたカレーを地図上に記録して、あなただけのカレーマップを作成">
     <meta property="og:image" content="https://your-domain.com/assets/images/og-image.jpg">
 
     <!-- Twitter -->
     <meta property="twitter:card" content="summary_large_image">
     <meta property="twitter:url" content="https://your-domain.com/">
-    <meta property="twitter:title" content="カレーログ">
+    <meta property="twitter:title" content="セカカレ">
     <meta property="twitter:description" content="食べたカレーを地図上に記録して、あなただけのカレーマップを作成">
     <meta property="twitter:image" content="https://your-domain.com/assets/images/og-image.jpg">
 


### PR DESCRIPTION
## 概要
ページタイトルを「カレーログ」から「セカカレ」に変更しました。

## 変更内容
- index.htmlの<title>タグを更新
- Open Graph (og:title)のメタタグを更新
- Twitter Card (twitter:title)のメタタグを更新

## 原因
以前の変更が現在のブランチに反映されていなかったため、サーバー上のファイルが更新されませんでした。

Fixes #12

Generated with [Claude Code](https://claude.ai/code)