### PR TITLE
fix: Places API (New)のエラーを修正し、アイコン表示を改善

### DIFF
--- a/assets/js/config.template.js
+++ b/assets/js/config.template.js
@@ -27,8 +27,8 @@ const Config = {
         // 地図のデフォルトズームレベル
         defaultZoom: 15,
 
-        // 検索結果の最大表示数
-        maxSearchResults: 30,
+        // 検索結果の最大表示数（API制限により最大20）
+        maxSearchResults: 20,
 
         // 自動検索の遅延時間（ミリ秒）
         autoSearchDelay: 500,


### PR DESCRIPTION
## 概要

Issue #31 で報告されたカレー店アイコンが表示されない問題を修正しました。

## 問題の原因
1. `google.maps.places.Place.searchByText`のレスポンス処理が不適切
2. Places API (New) がページネーションをサポートしていないのに実装していた
3. APIの最大20件制限を超えて30件取得しようとしていた

## 修正内容
- ページネーション処理を削除
- 最大表示件数を20件に調整
- Promise処理とエラー処理を改善

Closes #31

Generated with [Claude Code](https://claude.ai/code)