### PR TITLE
fix: Places API locationBias エラーを修正

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -208,16 +208,11 @@ async function autoSearchCurryShops(location) {
         console.log(`検索中... (座標: ${lat}, ${lng}, 範囲: ${searchRadius}m)`);
 
         // 評価を含めて取得するため、ratingフィールドを追加
-        // locationBiasをcircleパラメータで指定して検索範囲を設定
+        // locationBiasを文字列形式で指定（circle:radius@lat,lng）
         const request = {
             textQuery: 'カレー',
             fields: ['displayName', 'location', 'businessStatus', 'formattedAddress', 'rating', 'id'],
-            locationBias: {
-                circle: {
-                    center: { lat: lat, lng: lng },
-                    radius: searchRadius  // メートル単位で指定
-                }
-            },
+            locationBias: `circle:${searchRadius}@${lat},${lng}`,
             maxResultCount: 20  // APIの最大値は20
         };
 


### PR DESCRIPTION
## 概要

Issue #31 で報告された Places API の locationBias エラーを修正しました。

## 問題の原因
- `locationBias` がオブジェクト形式（`circle: { center: {...}, radius: ... }`）で指定されていた
- Places API (New) の仕様と一致していなかった

## 修正内容
Places API (New) の仕様に準拠して、`locationBias` を文字列形式に変更：

```javascript
locationBias: `circle:${searchRadius}@${lat},${lng}`
```

この形式は `circle:radius@lat,lng` というフォーマットで、半径（メートル単位）と中心座標を指定します。

ズームレベルに応じた動的な検索範囲は維持されます。

Closes #31

Generated with [Claude Code](https://claude.ai/code)