### PR TITLE
fix: Google Maps API対応のCSPヘッダーを修正

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -37,8 +37,8 @@
     # HSTS (HTTP Strict Transport Security) - 1年間
     Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
 
-    # Content Security Policy (基本設定)
-    Header always set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self'"
+    # Content Security Policy (基本設定 + Google Maps API対応)
+    Header always set Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://cdnjs.cloudflare.com https://maps.googleapis.com https://maps.gstatic.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com https://maps.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https: blob:; connect-src 'self' https://maps.googleapis.com https://maps.gstatic.com; frame-src 'self' https://www.google.com https://maps.google.com"
 
     # 権限ポリシー（旧Feature-Policy）
     Header always set Permissions-Policy "geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()"


### PR DESCRIPTION
## 概要

Google Maps APIが読み込めない問題を修正しました。

## 変更内容

Content-Security-PolicyヘッダーにGoogle Maps APIの必要なドメインを追加:
- maps.googleapis.com, maps.gstatic.com をscript-srcに追加
- maps.googleapis.com をstyle-srcに追加
- blob: をimg-srcに追加（マーカー画像用）
- maps.googleapis.com, maps.gstatic.com をconnect-srcに追加
- www.google.com, maps.google.com をframe-srcに追加（Street View用）

Related to #42

Generated with [Claude Code](https://claude.ai/code)