### PR TITLE
feat: 検索機能の改善 - 30件表示と動的検索半径の実装

### DIFF
--- a/assets/js/config.template.js
+++ b/assets/js/config.template.js
@@ -27,8 +27,8 @@ const Config = {
         // 地図のデフォルトズームレベル
         defaultZoom: 15,
 
-        // 検索結果の最大表示数（API制限により最大20）
-        maxSearchResults: 20,
+        // 検索結果の最大表示数（ページネーションで30件取得）
+        maxSearchResults: 30,
 
         // 自動検索の遅延時間（ミリ秒）
         autoSearchDelay: 500,


### PR DESCRIPTION
## 概要
検索機能を改善し、30件表示とズームレベルに応じた動的検索半径を実装しました。

## 変更内容
- config.template.jsのmaxSearchResultsを30に変更
- Places API (New) のページネーション実装
  - 1回目: 20件取得
  - 2回目: pageTokenで追加10件取得
  - 合計最大30件を評価順でソート
- ズームレベルに応じた動的検索半径の実装
  - ズーム15+: 1km
  - ズーム12-14: 3km
  - ズーム10-11: 10km
  - ズーム9以下: 20km
- ページネーションエラーのハンドリング追加

Resolves #47

----

Generated with [Claude Code](https://claude.ai/code)