### PR TITLE
fix: Places API実装の修正 - ページネーション削除と動的検索半径の実装

### DIFF
--- a/assets/js/config.template.js
+++ b/assets/js/config.template.js
@@ -27,8 +27,8 @@ const Config = {
         // 地図のデフォルトズームレベル
         defaultZoom: 15,
 
-        // 検索結果の最大表示数（API制限により最大20）
-        maxSearchResults: 20,
+        // 検索結果の最大表示数
+        maxSearchResults: 30,
 
         // 自動検索の遅延時間（ミリ秒）
         autoSearchDelay: 500,


### PR DESCRIPTION
## 概要
検索機能の修正を実施しました。Places API (New)はpageTokenをサポートしていないため、ページネーションを使用せず、1回のリクエストで最大30件を取得するように修正しました。

## 変更内容
- config.template.jsのmaxSearchResultsを30に変更
- API呼び出しでmaxResultCount: 30を設定（APIは20件に制限する可能性あり）
- ページネーション機能を削除（Places API Newは非対応）
- locationBiasはシンプルな座標形式を維持
- ズームレベルに応じた動的検索半径を実装
  - ズーム15+: 1km
  - ズーム12-14: 3km
  - ズーム10-11: 10km
  - ズーム9以下: 20km

Resolves #47

---
Generated with [Claude Code](https://claude.ai/code)