### PR TITLE
緊急修正: 訪問済み店舗の「食べた」ボタンが押せない問題

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -553,12 +553,12 @@ function showPopup(place) {
         document.getElementById('popupTitle').textContent = titleText;
         document.getElementById('popupAddress').textContent = place.vicinity;
 
-        // 訪問済みの場合はボタンを無効化または変更
+        // 訪問済みの場合はボタンのテキストを変更（再訪問可能）
         const btnAte = document.getElementById('btnAte');
         if (isVisited) {
             btnAte.textContent = '✅ 訪問済み';
-            btnAte.disabled = true;
-            btnAte.style.opacity = '0.6';
+            btnAte.disabled = false;  // 再訪問記録を可能にする
+            btnAte.style.opacity = '0.8';  // 少し透明度を上げて訪問済みを表現
         } else {
             btnAte.textContent = '🍛 食べた！';
             btnAte.disabled = false;


### PR DESCRIPTION
## 🐛 問題
訪問済み店舗で「食べた」ボタンが無効化されていたため、再訪問記録ができない状態でした。

## ✅ 修正内容
- `showPopup`関数で`btnAte.disabled = false`に変更
- 訪問済み店舗でも再訪問記録が可能に
- ボタンの透明度を0.8に調整して視覚的に区別

Closes #54

Generated with [Claude Code](https://claude.ai/code)