### PR TITLE
feat: ヘッダーティッカー機能実装

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -187,6 +187,58 @@ body {
     font-size: 12px;
 }
 
+/* ティッカーコンテナ */
+.ticker-container {
+    padding: 10px;
+    background: #f8f9fa;
+    border: 1px solid #dee2e6;
+    margin: 10px;
+    border-radius: 5px;
+    font-size: 14px;
+    overflow: hidden;
+    position: relative;
+    min-height: 24px;
+}
+
+/* ティッカーアイテム */
+.ticker-item {
+    opacity: 0;
+    transition: opacity 0.5s ease-in-out;
+}
+
+.ticker-item.active {
+    opacity: 1;
+}
+
+/* ティッカーカテゴリ */
+.ticker-category {
+    font-weight: bold;
+    color: #666;
+    margin-right: 8px;
+}
+
+/* ティッカーリンク */
+.ticker-link {
+    color: #333;
+    text-decoration: none;
+    transition: color 0.3s;
+}
+
+.ticker-link:hover {
+    color: #0066cc;
+    text-decoration: underline;
+}
+
+/* PRカテゴリの特別スタイル */
+.ticker-container.pr-category {
+    background: #fffbf0;
+    border-color: #f5a623;
+}
+
+.ticker-container.pr-category .ticker-category {
+    color: #f5a623;
+}
+
 /* マーカーアニメーション */
 @keyframes markerScaleIn {
     from {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -699,9 +699,14 @@ function displayLogs() {
 
 // デバッグ情報を更新
 function updateDebugInfo(html) {
-    const debugElement = document.getElementById('debugInfo');
-    if (debugElement) {
-        debugElement.innerHTML = html;
+    // デバッグモードの場合のみ更新
+    const isDebugMode = localStorage.getItem('sekakare_debug') === 'true';
+    if (isDebugMode) {
+        const debugElement = document.getElementById('debugInfo');
+        if (debugElement) {
+            debugElement.innerHTML = html;
+            debugElement.style.display = 'block';
+        }
     }
 }
 

--- a/assets/js/ticker.js
+++ b/assets/js/ticker.js
@@ -1,0 +1,250 @@
+// ティッカー機能実装
+(function() {
+    // 定数
+    const CSV_URL = 'https://docs.google.com/spreadsheets/d/e/2PACX-1vR5A92ZAN-APb-JPjiUOOyQSZoR1Owl6vbn2kz5sKu0RVrptYi7aw_GtA-pTO1Oc_YKtg7arooYXUBk/pub?gid=0&single=true&output=csv';
+    const ROTATION_INTERVAL = 5000; // 5秒
+    const MAX_ITEMS = 10; // 最大表示件数
+    const CACHE_KEY = 'sekakare_ticker_data';
+    const CACHE_DURATION = 5 * 60 * 1000; // 5分間キャッシュ
+
+    // 状態管理
+    let tickerData = [];
+    let currentIndex = 0;
+    let rotationTimer = null;
+
+    // 初期化関数
+    function initTicker() {
+        // デバッグモード判定
+        const isDebugMode = localStorage.getItem('sekakare_debug') === 'true';
+
+        const debugInfo = document.getElementById('debugInfo');
+        const tickerContainer = document.getElementById('tickerContainer');
+
+        if (isDebugMode) {
+            // デバッグモード: デバッグ情報を表示
+            if (debugInfo) debugInfo.style.display = 'block';
+            if (tickerContainer) tickerContainer.style.display = 'none';
+            if (rotationTimer) {
+                clearInterval(rotationTimer);
+                rotationTimer = null;
+            }
+        } else {
+            // 通常モード: ティッカーを表示
+            if (debugInfo) debugInfo.style.display = 'none';
+            if (tickerContainer) tickerContainer.style.display = 'block';
+
+            // ティッカーデータを読み込み
+            loadTickerData();
+        }
+    }
+
+    // CSVデータを読み込み
+    async function loadTickerData() {
+        try {
+            // キャッシュチェック
+            const cached = getCachedData();
+            if (cached) {
+                console.log('キャッシュからティッカーデータを読み込み');
+                tickerData = cached;
+                startTicker();
+                return;
+            }
+
+            // CSVを取得
+            console.log('CSVからティッカーデータを取得中...');
+            const response = await fetch(CSV_URL);
+
+            if (!response.ok) {
+                throw new Error('CSV取得失敗: ' + response.status);
+            }
+
+            const csvText = await response.text();
+
+            // Papaparseでパース
+            Papa.parse(csvText, {
+                header: true,
+                skipEmptyLines: true,
+                complete: function(results) {
+                    if (results.data && results.data.length > 0) {
+                        console.log('CSV解析成功:', results.data.length + '件');
+                        processTickerData(results.data);
+                    } else {
+                        console.error('CSVデータが空です');
+                        showFallbackDebugInfo();
+                    }
+                },
+                error: function(error) {
+                    console.error('CSV解析エラー:', error);
+                    showFallbackDebugInfo();
+                }
+            });
+
+        } catch (error) {
+            console.error('ティッカーデータ読み込みエラー:', error);
+            showFallbackDebugInfo();
+        }
+    }
+
+    // ティッカーデータを処理
+    function processTickerData(data) {
+        const now = new Date();
+
+        // フィルタリング: status=active かつ期限内
+        const filtered = data.filter(item => {
+            if (item.status !== 'active') return false;
+
+            if (item.expires_at && item.expires_at.trim() !== '') {
+                const expiryDate = new Date(item.expires_at);
+                if (expiryDate < now) return false;
+            }
+
+            return true;
+        });
+
+        // ソート: priority昇順 → published_at降順
+        filtered.sort((a, b) => {
+            // priority比較
+            const priorityA = parseInt(a.priority) || 999;
+            const priorityB = parseInt(b.priority) || 999;
+            if (priorityA !== priorityB) {
+                return priorityA - priorityB;
+            }
+
+            // published_at比較
+            const dateA = a.published_at ? new Date(a.published_at) : new Date(0);
+            const dateB = b.published_at ? new Date(b.published_at) : new Date(0);
+            return dateB - dateA;
+        });
+
+        // 最大件数制限
+        tickerData = filtered.slice(0, MAX_ITEMS);
+
+        console.log('ティッカーデータ処理完了:', tickerData.length + '件');
+
+        // キャッシュに保存
+        setCachedData(tickerData);
+
+        // ティッカー開始
+        startTicker();
+    }
+
+    // ティッカー開始
+    function startTicker() {
+        if (tickerData.length === 0) {
+            console.log('表示するティッカーデータがありません');
+            showFallbackDebugInfo();
+            return;
+        }
+
+        // 最初のアイテムを表示
+        currentIndex = 0;
+        displayTickerItem(currentIndex);
+
+        // ローテーション開始
+        if (rotationTimer) {
+            clearInterval(rotationTimer);
+        }
+
+        rotationTimer = setInterval(() => {
+            rotateTickerItem();
+        }, ROTATION_INTERVAL);
+    }
+
+    // ティッカーアイテムを表示
+    function displayTickerItem(index) {
+        const item = tickerData[index];
+        if (!item) return;
+
+        const tickerContainer = document.getElementById('tickerContainer');
+        const tickerItem = document.getElementById('tickerItem');
+        const categorySpan = tickerItem.querySelector('.ticker-category');
+        const linkElement = tickerItem.querySelector('.ticker-link');
+
+        // フェードアウト
+        tickerItem.classList.remove('active');
+
+        setTimeout(() => {
+            // カテゴリ別表示
+            if (item.category === 'pr') {
+                categorySpan.textContent = '[PR]';
+                tickerContainer.classList.add('pr-category');
+            } else {
+                categorySpan.textContent = '[ニュース]';
+                tickerContainer.classList.remove('pr-category');
+            }
+
+            // タイトルとリンク設定
+            linkElement.textContent = item.title || '（タイトルなし）';
+            linkElement.href = item.url || '#';
+
+            // フェードイン
+            tickerItem.classList.add('active');
+        }, 250);
+    }
+
+    // ティッカーアイテムをローテーション
+    function rotateTickerItem() {
+        currentIndex = (currentIndex + 1) % tickerData.length;
+        displayTickerItem(currentIndex);
+    }
+
+    // フォールバック: デバッグ情報を表示
+    function showFallbackDebugInfo() {
+        console.log('ティッカー表示失敗: デバッグ情報にフォールバック');
+        const debugInfo = document.getElementById('debugInfo');
+        const tickerContainer = document.getElementById('tickerContainer');
+
+        if (debugInfo) debugInfo.style.display = 'block';
+        if (tickerContainer) tickerContainer.style.display = 'none';
+
+        if (rotationTimer) {
+            clearInterval(rotationTimer);
+            rotationTimer = null;
+        }
+    }
+
+    // キャッシュからデータ取得
+    function getCachedData() {
+        try {
+            const cached = localStorage.getItem(CACHE_KEY);
+            if (!cached) return null;
+
+            const parsed = JSON.parse(cached);
+            const now = Date.now();
+
+            // キャッシュ期限チェック
+            if (parsed.timestamp && (now - parsed.timestamp) < CACHE_DURATION) {
+                return parsed.data;
+            }
+
+            // 期限切れキャッシュを削除
+            localStorage.removeItem(CACHE_KEY);
+        } catch (error) {
+            console.error('キャッシュ読み込みエラー:', error);
+        }
+        return null;
+    }
+
+    // キャッシュにデータ保存
+    function setCachedData(data) {
+        try {
+            const cacheData = {
+                timestamp: Date.now(),
+                data: data
+            };
+            localStorage.setItem(CACHE_KEY, JSON.stringify(cacheData));
+        } catch (error) {
+            console.error('キャッシュ保存エラー:', error);
+        }
+    }
+
+    // DOMContentLoaded時に初期化
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initTicker);
+    } else {
+        initTicker();
+    }
+
+    // デバッグモード切り替え時に再初期化（外部から呼び出し可能）
+    window.reinitializeTicker = initTicker;
+})();

--- a/index.html
+++ b/index.html
@@ -50,6 +50,9 @@
     <!-- 設定ファイル（APIキー管理） -->
     <script src="assets/js/config.js"></script>
 
+    <!-- Papaparse for CSV parsing -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js"></script>
+
     <!-- Google Analytics 4 -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
     <script>
@@ -65,8 +68,15 @@
         <p>世界をカレーで塗り尽くそう！あなたのカレー体験を記録</p>
     </div>
 
-    <div class="debug-info" id="debugInfo">
+    <div class="debug-info" id="debugInfo" style="display: none;">
         <strong>起動中...</strong> カレー店データを読み込み中です
+    </div>
+
+    <div class="ticker-container" id="tickerContainer" style="display: none;">
+        <div class="ticker-item" id="tickerItem">
+            <span class="ticker-category"></span>
+            <a class="ticker-link" href="#" target="_blank"></a>
+        </div>
     </div>
 
     <div class="container">
@@ -102,5 +112,8 @@
 
     <!-- メインアプリケーションJS -->
     <script src="assets/js/app.js"></script>
+
+    <!-- ティッカー機能JS -->
+    <script src="assets/js/ticker.js"></script>
 </body>
 </html>

--- a/ticker-test.html
+++ b/ticker-test.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ティッカー機能テスト</title>
+    <style>
+        body {
+            font-family: 'Helvetica Neue', Arial, sans-serif;
+            margin: 20px;
+            background: #f5f5f5;
+        }
+        .test-container {
+            max-width: 800px;
+            margin: 0 auto;
+            background: white;
+            padding: 20px;
+            border-radius: 10px;
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+        }
+        h1 {
+            color: #333;
+            border-bottom: 2px solid #f5a623;
+            padding-bottom: 10px;
+        }
+        .controls {
+            margin: 20px 0;
+            padding: 20px;
+            background: #f8f9fa;
+            border-radius: 5px;
+        }
+        button {
+            padding: 10px 20px;
+            margin: 5px;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            font-size: 14px;
+            transition: all 0.3s;
+        }
+        .btn-primary {
+            background: #f5a623;
+            color: white;
+        }
+        .btn-primary:hover {
+            background: #e69514;
+        }
+        .btn-secondary {
+            background: #6c757d;
+            color: white;
+        }
+        .btn-secondary:hover {
+            background: #5a6268;
+        }
+        .status {
+            padding: 15px;
+            margin: 20px 0;
+            border-radius: 5px;
+            font-weight: bold;
+        }
+        .status.debug {
+            background: #d4edda;
+            color: #155724;
+            border: 1px solid #c3e6cb;
+        }
+        .status.normal {
+            background: #d1ecf1;
+            color: #0c5460;
+            border: 1px solid #bee5eb;
+        }
+        iframe {
+            width: 100%;
+            height: 300px;
+            border: 1px solid #ddd;
+            border-radius: 5px;
+            margin-top: 20px;
+        }
+        .info-box {
+            background: #fff3cd;
+            border: 1px solid #ffc107;
+            color: #856404;
+            padding: 15px;
+            border-radius: 5px;
+            margin: 20px 0;
+        }
+        code {
+            background: #f4f4f4;
+            padding: 2px 6px;
+            border-radius: 3px;
+            font-family: 'Courier New', monospace;
+        }
+    </style>
+</head>
+<body>
+    <div class="test-container">
+        <h1>🎫 ティッカー機能テストページ</h1>
+
+        <div class="info-box">
+            <strong>📋 テスト概要:</strong><br>
+            このページでは、ヘッダーティッカー機能の動作確認ができます。<br>
+            デバッグモードの切り替えで、ティッカー表示とデバッグ情報表示を切り替えられます。
+        </div>
+
+        <div class="controls">
+            <h3>コントロールパネル</h3>
+
+            <div id="currentStatus" class="status normal">
+                現在のモード: <strong>通常モード（ティッカー表示）</strong>
+            </div>
+
+            <button class="btn-primary" onclick="toggleDebugMode()">
+                🔄 デバッグモード切り替え
+            </button>
+
+            <button class="btn-secondary" onclick="clearCache()">
+                🗑️ キャッシュクリア
+            </button>
+
+            <button class="btn-secondary" onclick="reloadPage()">
+                🔃 ページリロード
+            </button>
+        </div>
+
+        <div class="info-box">
+            <strong>💡 使い方:</strong>
+            <ul>
+                <li><code>デバッグモード切り替え</code> - localStorage の sekakare_debug フラグを切り替えます</li>
+                <li><code>キャッシュクリア</code> - CSVデータのキャッシュをクリアして最新データを取得</li>
+                <li><code>ページリロード</code> - iframeをリロードして変更を反映</li>
+            </ul>
+        </div>
+
+        <h3>📱 実際の表示:</h3>
+        <iframe id="testFrame" src="index.html"></iframe>
+
+        <div class="info-box">
+            <strong>🔍 確認項目:</strong>
+            <ul>
+                <li>✅ CSV正常読み込み・パース</li>
+                <li>✅ priority/日付順ソート</li>
+                <li>✅ 5秒間隔ローテーション</li>
+                <li>✅ クリックでURL遷移（新しいタブ）</li>
+                <li>✅ デバッグモード切り替え</li>
+                <li>✅ PR記事の特別表示（黄色背景）</li>
+                <li>✅ CSVデータのキャッシング（5分間）</li>
+            </ul>
+        </div>
+    </div>
+
+    <script>
+        // 初期状態を確認
+        function checkCurrentMode() {
+            const isDebugMode = localStorage.getItem('sekakare_debug') === 'true';
+            const statusElement = document.getElementById('currentStatus');
+
+            if (isDebugMode) {
+                statusElement.className = 'status debug';
+                statusElement.innerHTML = '現在のモード: <strong>デバッグモード（デバッグ情報表示）</strong>';
+            } else {
+                statusElement.className = 'status normal';
+                statusElement.innerHTML = '現在のモード: <strong>通常モード（ティッカー表示）</strong>';
+            }
+        }
+
+        // デバッグモード切り替え
+        function toggleDebugMode() {
+            const currentMode = localStorage.getItem('sekakare_debug') === 'true';
+            const newMode = !currentMode;
+
+            localStorage.setItem('sekakare_debug', newMode.toString());
+
+            checkCurrentMode();
+
+            // iframeのコンテンツウィンドウにアクセスして再初期化を試みる
+            try {
+                const iframe = document.getElementById('testFrame');
+                if (iframe && iframe.contentWindow && iframe.contentWindow.reinitializeTicker) {
+                    iframe.contentWindow.reinitializeTicker();
+                    console.log('ティッカーを再初期化しました');
+                } else {
+                    // 再初期化関数が利用できない場合はリロード
+                    reloadPage();
+                }
+            } catch (e) {
+                console.log('再初期化できないためリロードします');
+                reloadPage();
+            }
+        }
+
+        // キャッシュクリア
+        function clearCache() {
+            localStorage.removeItem('sekakare_ticker_data');
+            alert('CSVキャッシュをクリアしました。ページをリロードすると最新データを取得します。');
+        }
+
+        // ページリロード
+        function reloadPage() {
+            const iframe = document.getElementById('testFrame');
+            iframe.src = iframe.src;
+        }
+
+        // ページ読み込み時に状態をチェック
+        window.addEventListener('load', function() {
+            checkCurrentMode();
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## 概要
ヘッダーエリアにテキストティッカー（ニュース表示）機能を追加しました。
現在のデバッグ情報表示と切り替え可能です。

## 実装内容
- Google Sheets CSVからデータを取得・解析
- status=activeかつ期限内のアイテムのみ表示
- priority昇順、published_at降順でソート
- 5秒間隔でフェードイン/アウトによるローテーション
- PRカテゴリは黄色背景で特別表示
- デバッグモード切り替え機能
- 5分間のローカルストレージキャッシング
- テストページ追加

Closes #56

Generated with [Claude Code](https://claude.ai/code)