### PR TITLE
refactor: レビューフィードバック対応 - 関数名修正とデッドコード整理

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -697,26 +697,13 @@ function displayLogs() {
     `).join('');
 }
 
-// デバッグ情報を更新（ティッカーモード対応）
+// デバッグ情報を更新（デバッグモード削除・常に非表示）
 function updateDebugInfo(html) {
     const debugElement = document.getElementById('debugInfo');
-    const isDebugMode = localStorage.getItem('sekakare_debug') === 'true';
 
     if (debugElement) {
-        debugElement.innerHTML = html;
-
-        // デバッグモードでない場合はティッカーを優先表示
-        if (!isDebugMode) {
-            // ティッカーが有効でない場合のみデバッグ情報を表示
-            const tickerContainer = document.getElementById('tickerContainer');
-            if (tickerContainer && tickerContainer.style.display !== 'block') {
-                // ティッカーエラー時のフォールバック
-                debugElement.style.display = 'block';
-            }
-        } else {
-            // デバッグモードの場合は常に表示
-            debugElement.style.display = 'block';
-        }
+        // デバッグモード削除により常に非表示
+        debugElement.style.display = 'none';
     }
 }
 

--- a/assets/js/ticker.js
+++ b/assets/js/ticker.js
@@ -253,17 +253,7 @@ async function initTicker() {
     // DOM要素の初期キャッシュ
     initDOMElements();
 
-    // デバッグモードチェック
-    const isDebugMode = localStorage.getItem('sekakare_debug') === 'true';
-
-    if (isDebugMode) {
-        console.log('デバッグモードが有効 - ティッカーを非表示');
-        if (elements.tickerContainer) {
-            elements.tickerContainer.style.display = 'none';
-        }
-        document.getElementById('debugInfo').style.display = 'block';
-        return;
-    }
+    // 常にティッカーを表示（デバッグモード削除済み）
 
     try {
         // データ取得
@@ -295,7 +285,7 @@ async function initTicker() {
             isTickerEnabled = true;
         } else {
             console.log('表示するニュースがありません');
-            fallbackToDebugMode();
+            handleTickerError();
         }
     } catch (error) {
         console.error('ティッカー初期化エラー:', error);
@@ -303,13 +293,17 @@ async function initTicker() {
     }
 }
 
-// デバッグモードへフォールバック
-function fallbackToDebugMode() {
-    console.log('デバッグモードへフォールバック');
+// ティッカーエラー時の処理
+function handleTickerError() {
+    console.log('ティッカーエラー - ティッカーを非表示に設定');
     if (elements.tickerContainer) {
         elements.tickerContainer.style.display = 'none';
     }
-    document.getElementById('debugInfo').style.display = 'block';
+    // デバッグ情報は常に非表示
+    const debugInfo = document.getElementById('debugInfo');
+    if (debugInfo) {
+        debugInfo.style.display = 'none';
+    }
 }
 
 // クリーンアップ処理（メモリリーク防止）
@@ -333,14 +327,7 @@ function cleanup() {
 // ページアンロード時のクリーンアップ
 window.addEventListener('beforeunload', cleanup);
 
-// デバッグモード切り替え監視
-window.addEventListener('storage', (e) => {
-    if (e.key === 'sekakare_debug') {
-        console.log('デバッグモード設定が変更されました');
-        cleanup();
-        initTicker();
-    }
-});
+// Storage イベント監視（デバッグモード削除済み）
 
 // エクスポート（テスト用）
 if (typeof module !== 'undefined' && module.exports) {


### PR DESCRIPTION
## 概要
レビューフィードバックに基づき、関数名の修正とデッドコードの整理を行いました。

## 修正内容
- `fallbackToDebugMode` を `handleTickerError` にリネーム
- 残存していたデバッグモード関連のコードを削除
- `updateDebugInfo` 関数を簡潔化（常にdisplay: none設定）

Fixes #60

Generated with [Claude Code](https://claude.ai/code)