### PR TITLE
fix: 関数呼び出しエラーを修正 - fallbackToDebugMode → handleTickerError

### DIFF
--- a/assets/js/ticker.js
+++ b/assets/js/ticker.js
@@ -295,21 +295,22 @@ async function initTicker() {
             isTickerEnabled = true;
         } else {
             console.log('表示するニュースがありません');
-            fallbackToDebugMode();
+            handleTickerError();
         }
     } catch (error) {
         console.error('ティッカー初期化エラー:', error);
-        fallbackToDebugMode();
+        handleTickerError();
     }
 }
 
-// デバッグモードへフォールバック
-function fallbackToDebugMode() {
-    console.log('デバッグモードへフォールバック');
+// エラー時の処理
+function handleTickerError() {
+    console.log('ティッカーエラー処理');
     if (elements.tickerContainer) {
         elements.tickerContainer.style.display = 'none';
     }
-    document.getElementById('debugInfo').style.display = 'block';
+    // デバッグモード削除により、エラー時もデバッグ情報は非表示
+    document.getElementById('debugInfo').style.display = 'none';
 }
 
 // クリーンアップ処理（メモリリーク防止）


### PR DESCRIPTION
## 概要
致命的なバグを修正しました。前回のリファクタリングで更新漏れしていた関数呼び出しを修正しました。

## 修正内容
- `fallbackToDebugMode` 関数を `handleTickerError` にリネーム
- 全ての関数呼び出しを新しい名前に更新
- エラー時もデバッグ情報を非表示にするよう修正

Fixes #60

Generated with [Claude Code](https://claude.ai/code)