### PR TITLE
faviconとアプリアイコンの読み込み設定を復旧

### DIFF
--- a/assets/icons/site.webmanifest
+++ b/assets/icons/site.webmanifest
@@ -1,1 +1,0 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
     <meta name="apple-mobile-web-app-title" content="セカカレ">
     <meta name="application-name" content="セカカレ">
     <meta name="msapplication-TileColor" content="#ff6b00">
-    <meta name="msapplication-TileImage" content="assets/icons/android-chrome-192x192.png">
+    <meta name="msapplication-TileImage" content="/assets/icons/android-chrome-192x192.png">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website">

--- a/index.html
+++ b/index.html
@@ -8,26 +8,30 @@
     <meta name="keywords" content="カレー,グルメ,地図,ログ,記録,レストラン">
 
     <!-- Favicon -->
-    <link rel="icon" type="image/x-icon" href="assets/icons/favicon.ico">
-    <link rel="icon" type="image/png" sizes="32x32" href="assets/icons/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="assets/icons/favicon-16x16.png">
+    <link rel="icon" type="image/x-icon" href="/assets/icons/favicon.ico">
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/favicon-16x16.png">
 
     <!-- Apple Touch Icon -->
-    <link rel="apple-touch-icon" sizes="180x180" href="assets/icons/apple-touch-icon.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png">
 
-    <!-- Android Chrome Icons & Web App Manifest -->
-    <link rel="manifest" href="assets/icons/site.webmanifest">
+    <!-- Android Chrome Icons -->
+    <link rel="icon" type="image/png" sizes="192x192" href="/assets/icons/android-chrome-192x192.png">
+    <link rel="icon" type="image/png" sizes="512x512" href="/assets/icons/android-chrome-512x512.png">
+
+    <!-- Web App Manifest -->
+    <link rel="manifest" href="/manifest.json">
 
     <!-- Theme Color for Mobile Browsers -->
-    <meta name="theme-color" content="#f5a623">
+    <meta name="theme-color" content="#ff6b00">
 
     <!-- Additional Mobile Meta Tags -->
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="default">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <meta name="apple-mobile-web-app-title" content="セカカレ">
     <meta name="application-name" content="セカカレ">
-    <meta name="msapplication-TileColor" content="#f5a623">
+    <meta name="msapplication-TileColor" content="#ff6b00">
     <meta name="msapplication-TileImage" content="assets/icons/android-chrome-192x192.png">
 
     <!-- Open Graph / Facebook -->

--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
     <meta name="description" content="食べたカレーを地図上に記録して、あなただけのカレーマップを作成。全国のカレー店を発見して、カレー巡りを楽しもう！">
     <meta name="keywords" content="カレー,グルメ,地図,ログ,記録,レストラン">
 
+    <!-- Preload critical icons for performance -->
+    <link rel="preload" as="image" href="/assets/icons/favicon-32x32.png">
+    <link rel="preload" as="image" href="/assets/icons/apple-touch-icon.png">
+
     <!-- Favicon -->
     <link rel="icon" type="image/x-icon" href="/assets/icons/favicon.ico">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/favicon-32x32.png">

--- a/index.html
+++ b/index.html
@@ -8,11 +8,12 @@
     <meta name="keywords" content="カレー,グルメ,地図,ログ,記録,レストラン">
 
     <!-- Preload critical icons for performance -->
-    <link rel="preload" as="image" href="/assets/icons/favicon-32x32.png">
-    <link rel="preload" as="image" href="/assets/icons/apple-touch-icon.png">
+    <link rel="preload" as="image" type="image/x-icon" href="/assets/icons/favicon.ico">
+    <link rel="preload" as="image" type="image/png" href="/assets/icons/favicon-32x32.png">
+    <link rel="preload" as="image" type="image/png" href="/assets/icons/apple-touch-icon.png">
 
     <!-- Favicon -->
-    <link rel="icon" type="image/x-icon" href="/assets/icons/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="/assets/icons/favicon.ico" sizes="any">
     <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/favicon-16x16.png">
 

--- a/manifest.json
+++ b/manifest.json
@@ -11,12 +11,14 @@
     {
       "src": "/assets/icons/android-chrome-192x192.png",
       "sizes": "192x192",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     },
     {
       "src": "/assets/icons/android-chrome-512x512.png",
       "sizes": "512x512",
-      "type": "image/png"
+      "type": "image/png",
+      "purpose": "any maskable"
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -12,13 +12,25 @@
       "src": "/assets/icons/android-chrome-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/assets/icons/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "maskable"
     },
     {
       "src": "/assets/icons/android-chrome-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/assets/icons/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
     }
   ]
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,22 @@
+{
+  "name": "セカカレ - カレー店訪問記録",
+  "short_name": "セカカレ",
+  "description": "世界をカレーで塗り尽くそう！カレー店訪問記録アプリ",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ff6b00",
+  "orientation": "portrait",
+  "icons": [
+    {
+      "src": "/assets/icons/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/assets/icons/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

ロールバックで消えてしまったfaviconやアプリアイコンの読み込み設定を復旧しました。

## 変更内容

- `index.html`にアイコン読み込み設定を追加
- PWA対応の`manifest.json`を新規作成
- テーマカラーをカレーオレンジ（#ff6b00）に統一

Fixes #68

Generated with [Claude Code](https://claude.ai/code)