### PR TITLE
feat: フッターとプライバシーポリシーページを追加

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -274,6 +274,41 @@ body {
     pointer-events: none;
 }
 
+/* フッター */
+.footer {
+    background: #2c2c2c;
+    color: white;
+    padding: 20px 15px;
+    text-align: center;
+    margin-top: 20px;
+}
+
+.footer-content {
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.footer-copyright {
+    margin-bottom: 10px;
+    font-size: 14px;
+}
+
+.footer-links {
+    margin-top: 10px;
+}
+
+.footer-links a {
+    color: #ff6b00;
+    text-decoration: none;
+    margin: 0 10px;
+    transition: color 0.3s;
+}
+
+.footer-links a:hover {
+    color: #ff8c00;
+    text-decoration: underline;
+}
+
 @media (max-width: 480px) {
     .header h1 {
         font-size: 20px;
@@ -281,5 +316,18 @@ body {
 
     #map {
         height: 60vh;
+    }
+
+    .footer {
+        padding: 15px 10px;
+    }
+
+    .footer-copyright {
+        font-size: 12px;
+    }
+
+    .footer-links a {
+        font-size: 12px;
+        margin: 0 5px;
     }
 }

--- a/index.html
+++ b/index.html
@@ -124,5 +124,14 @@
 
     <!-- メインアプリケーションJS -->
     <script src="assets/js/app.js"></script>
+
+    <footer class="footer">
+        <div class="footer-content">
+            <p class="footer-copyright">© 2024 セカカレ</p>
+            <nav class="footer-links">
+                <a href="privacy.html">プライバシーポリシー</a>
+            </nav>
+        </div>
+    </footer>
 </body>
 </html>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,234 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>プライバシーポリシー - セカカレ</title>
+    <meta name="description" content="セカカレのプライバシーポリシー">
+
+    <!-- Favicon -->
+    <link rel="icon" type="image/x-icon" href="/assets/icons/favicon.ico" sizes="any">
+    <link rel="icon" type="image/png" sizes="32x32" href="/assets/icons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/assets/icons/favicon-16x16.png">
+
+    <!-- Apple Touch Icon -->
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/icons/apple-touch-icon.png">
+
+    <!-- Theme Color for Mobile Browsers -->
+    <meta name="theme-color" content="#ff6b00">
+
+    <!-- CSSファイル -->
+    <link rel="stylesheet" href="assets/css/style.css">
+
+    <style>
+        .privacy-container {
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+            background: white;
+            min-height: 80vh;
+        }
+
+        .privacy-header {
+            background: #ff8c00;
+            color: white;
+            padding: 20px;
+            text-align: center;
+            margin-bottom: 30px;
+        }
+
+        .privacy-header h1 {
+            font-size: 28px;
+            margin-bottom: 10px;
+        }
+
+        .privacy-content {
+            padding: 0 20px;
+        }
+
+        .privacy-content h2 {
+            color: #ff6b00;
+            font-size: 20px;
+            margin-top: 30px;
+            margin-bottom: 15px;
+            border-bottom: 2px solid #ff6b00;
+            padding-bottom: 5px;
+        }
+
+        .privacy-content h3 {
+            color: #333;
+            font-size: 18px;
+            margin-top: 20px;
+            margin-bottom: 10px;
+        }
+
+        .privacy-content p {
+            line-height: 1.8;
+            color: #333;
+            margin-bottom: 15px;
+        }
+
+        .privacy-content ul {
+            margin-left: 20px;
+            margin-bottom: 15px;
+        }
+
+        .privacy-content li {
+            line-height: 1.8;
+            margin-bottom: 8px;
+        }
+
+        .back-link {
+            display: inline-block;
+            margin: 30px 0;
+            padding: 12px 30px;
+            background: #ff8c00;
+            color: white;
+            text-decoration: none;
+            border-radius: 25px;
+            transition: all 0.3s;
+        }
+
+        .back-link:hover {
+            background: #ff6b00;
+            transform: translateY(-2px);
+        }
+
+        .last-updated {
+            color: #666;
+            font-size: 14px;
+            text-align: right;
+            margin-top: 30px;
+            padding-top: 20px;
+            border-top: 1px solid #ddd;
+        }
+
+        @media (max-width: 480px) {
+            .privacy-header h1 {
+                font-size: 22px;
+            }
+
+            .privacy-content {
+                padding: 0 15px;
+            }
+
+            .privacy-content h2 {
+                font-size: 18px;
+            }
+
+            .privacy-content h3 {
+                font-size: 16px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="privacy-header">
+        <h1>プライバシーポリシー</h1>
+    </div>
+
+    <div class="privacy-container">
+        <div class="privacy-content">
+            <p>セカカレ（以下「当サービス」）は、ユーザーの皆様の個人情報保護に最大限配慮し、以下のプライバシーポリシーに基づいて情報を取り扱います。</p>
+
+            <h2>1. Google Analyticsの使用について</h2>
+            <p>当サービスでは、サービスの改善とユーザー体験の向上を目的として、Google Analyticsを使用しています。</p>
+
+            <h3>収集される情報</h3>
+            <ul>
+                <li>ページビュー数</li>
+                <li>訪問者数と訪問回数</li>
+                <li>セッション時間</li>
+                <li>デバイス情報（OS、ブラウザの種類など）</li>
+                <li>おおよその地域情報</li>
+            </ul>
+
+            <h3>データの使用目的</h3>
+            <ul>
+                <li>サービスの利用状況の分析</li>
+                <li>サービスの改善と最適化</li>
+                <li>ユーザー体験の向上</li>
+            </ul>
+
+            <p>Google Analyticsの詳細については、<a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer">Googleのプライバシーポリシー</a>をご確認ください。</p>
+
+            <h2>2. Cookieの使用について</h2>
+            <p>当サービスでは、以下の目的でCookieを使用しています。</p>
+
+            <h3>使用目的</h3>
+            <ul>
+                <li>Google Analyticsによるアクセス解析</li>
+                <li>ユーザーの設定や状態の保持</li>
+                <li>サービスの利便性向上</li>
+            </ul>
+
+            <p>Cookieの使用を望まない場合は、ブラウザの設定からCookieを無効化することができます。ただし、一部の機能が正常に動作しない可能性があります。</p>
+
+            <h2>3. 位置情報の取得について</h2>
+            <p>当サービスでは、カレー店の検索と地図表示機能を提供するため、ユーザーの位置情報を使用します。</p>
+
+            <h3>位置情報の使用目的</h3>
+            <ul>
+                <li>地図の初期表示位置の設定</li>
+                <li>現在地周辺のカレー店の検索</li>
+                <li>より便利な検索体験の提供</li>
+            </ul>
+
+            <h3>位置情報の取り扱い</h3>
+            <ul>
+                <li>位置情報の取得には、ユーザーの明示的な許可が必要です</li>
+                <li>位置情報はサーバーに送信・保存されません</li>
+                <li>位置情報はブラウザ内でのみ使用されます</li>
+                <li>位置情報の提供を拒否しても、サービスの基本機能は利用可能です</li>
+            </ul>
+
+            <h2>4. ローカルストレージの使用について</h2>
+            <p>当サービスでは、ユーザーのカレー記録を保存するために、ブラウザのローカルストレージ機能を使用しています。</p>
+
+            <h3>保存される情報</h3>
+            <ul>
+                <li>訪問したカレー店の名前</li>
+                <li>店舗の住所</li>
+                <li>訪問日時</li>
+            </ul>
+
+            <h3>ローカルストレージの特徴</h3>
+            <ul>
+                <li>すべてのデータはユーザーのブラウザ内にのみ保存されます</li>
+                <li>データはサーバーに送信されません</li>
+                <li>データは他のユーザーと共有されません</li>
+                <li>ブラウザのデータを削除すると、記録も削除されます</li>
+            </ul>
+
+            <h2>5. 第三者への情報提供</h2>
+            <p>当サービスは、以下の場合を除き、収集した情報を第三者に提供することはありません。</p>
+            <ul>
+                <li>ユーザーの同意がある場合</li>
+                <li>法令に基づく場合</li>
+                <li>人の生命、身体または財産の保護のために必要な場合</li>
+            </ul>
+
+            <h2>6. プライバシーポリシーの変更</h2>
+            <p>当サービスは、必要に応じて本プライバシーポリシーの内容を変更することがあります。変更後のプライバシーポリシーは、本ページに掲載した時点で効力を生じるものとします。</p>
+
+            <h2>7. お問い合わせ</h2>
+            <p>本プライバシーポリシーに関するお問い合わせは、GitHubリポジトリのIssueよりお願いいたします。</p>
+
+            <div class="last-updated">
+                最終更新日: 2024年10月4日
+            </div>
+
+            <a href="index.html" class="back-link">🏠 ホームへ戻る</a>
+        </div>
+    </div>
+
+    <footer class="footer">
+        <div class="footer-content">
+            <p class="footer-copyright">© 2024 セカカレ</p>
+            <nav class="footer-links">
+                <a href="privacy.html">プライバシーポリシー</a>
+            </nav>
+        </div>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## 概要
フッターとプライバシーポリシーページを追加しました。

## 変更内容
- index.htmlにフッターを追加（コピーライト表記とプライバシーポリシーへのリンク）
- フッター用のCSSスタイルを追加（背景色#2c2c2c、アクセントカラー#ff6b00）
- レスポンシブ対応を実装
- privacy.htmlページを作成

Closes #70

Generated with [Claude Code](https://claude.ai/code)