### PR TITLE
訪問済み店舗を半透明表示に変更して再訪問記録を可能に

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -264,6 +264,11 @@ body {
     position: relative;
 }
 
+/* 訪問済みマーカー（半透明） */
+.custom-marker.visited-marker {
+    opacity: 0.6;
+}
+
 /* アニメーションラッパー */
 .marker-animation-wrapper {
     animation: markerScaleIn 0.3s ease-out forwards;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,8 +1,5 @@
 // メインアプリケーションロジック
 
-// 定数定義
-const MAX_UNVISITED_DISPLAY = 10;  // 新発見特化モードでの最大表示件数
-
 let map;
 let currentPlace = null;
 let curryLogs = JSON.parse(localStorage.getItem(Config.storageKeys.curryLogs) || '[]');
@@ -256,8 +253,8 @@ async function autoSearchCurryShops(location) {
             // すべての店舗を表示（訪問済みも含む）
             clearMarkers();
 
-            // 店舗を評価でソート
-            let placesToShow = places.sort((a, b) => {
+            // 店舗を評価でソート（非破壊的）
+            let placesToShow = [...places].sort((a, b) => {
                 const ratingA = a.rating || 0;
                 const ratingB = b.rating || 0;
                 return ratingB - ratingA;  // 降順


### PR DESCRIPTION
## 変更内容

### 検索ロジックの改善
- 新発見特化モードの除外処理を削除
- すべての店舗を表示（訪問済み・未訪問の両方）
- 訪問済み店舗を視覚的に区別（半透明 + ✅マーク）

### マーカー表示の改善
- 訪問済みマーカーに `visited-marker` クラスを追加
- CSS で opacity: 0.6 を設定して半透明表示
- CSP 準拠（インラインスタイル不使用）

### ユーザー体験の向上
- 訪問済み店舗もクリック可能になり再訪問記録が可能
- デバッグ情報に未訪問・訪問済みの件数を表示
- すべての店舗情報を地図上で確認可能

Fixes #67

🤖 Generated with [Claude Code](https://claude.ai/code)