### PR TITLE
fix: HeatmapOverlay読み込みタイミングの修正

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -877,6 +877,17 @@ function loadGoogleMaps() {
         console.error('Google Maps APIの読み込みに失敗しました');
         updateDebugInfo('❌ Google Maps APIの読み込みに失敗しました');
     };
+
+    // Google Maps API読み込み後にheatmap-overlay.jsを読み込む
+    script.onload = () => {
+        const heatmapScript = document.createElement('script');
+        heatmapScript.src = 'assets/js/heatmap-overlay.js';
+        heatmapScript.onerror = () => {
+            console.error('heatmap-overlay.jsの読み込みに失敗しました');
+        };
+        document.head.appendChild(heatmapScript);
+    };
+
     document.head.appendChild(script);
 }
 

--- a/index.html
+++ b/index.html
@@ -147,9 +147,6 @@
         </div>
     </footer>
 
-    <!-- ヒートマップオーバーレイJS -->
-    <script src="assets/js/heatmap-overlay.js"></script>
-
     <!-- ティッカー機能JS -->
     <script src="assets/js/ticker.js"></script>
 


### PR DESCRIPTION
## 概要

Google Maps API読み込み後にheatmap-overlay.jsを動的にロードするように変更し、`HeatmapOverlay is not defined`エラーを解決しました。

## 変更内容

- index.htmlから静的なscriptタグを削除
- loadGoogleMaps()にonloadハンドラを追加し、Google Maps API読み込み完了後にheatmap-overlay.jsを動的ロード

Fixes #85

Generated with [Claude Code](https://claude.ai/code)