### PR TITLE
fix: hide hamburger button when menu is open

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -466,6 +466,13 @@ body {
     transform: translateY(-8px) rotate(-45deg);
 }
 
+/* メニューが開いているときはハンバーガーボタンを非表示 */
+.hamburger.active {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
 /* メニューオーバーレイ */
 .menu-overlay {
     position: fixed;


### PR DESCRIPTION
## Summary

Fixes #98 - Prevents overlapping X buttons on the top page hamburger menu.

## Changes
- Added CSS to hide hamburger button when menu is open
- Implemented Option A: `.hamburger.active` with `opacity: 0` and `pointer-events: none`
- Smooth fade-out transition for better UX

## Testing
- ✅ Hamburger button fades out when menu opens
- ✅ Only close button visible in slide menu
- ✅ No overlapping X buttons
- ✅ Smooth animation

---

Generated with [Claude Code](https://claude.ai/code)