### PR TITLE
feat: Phase 1-B-2 データ編集機能の実装

### DIFF
--- a/assets/css/logs.css
+++ b/assets/css/logs.css
@@ -481,6 +481,26 @@ body {
     outline-offset: 2px;
 }
 
+/* トースト通知のアニメーション */
+@keyframes fadeInOut {
+    0% {
+        opacity: 0;
+        transform: translateX(-50%) translateY(20px);
+    }
+    20% {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+    }
+    80% {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+    }
+    100% {
+        opacity: 0;
+        transform: translateX(-50%) translateY(-20px);
+    }
+}
+
 /* レスポンシブ対応 */
 @media (max-width: 600px) {
     .header h1 {


### PR DESCRIPTION
### 🎯 概要

Phase 1-B-2 として、ログページにデータ編集機能を実装しました。

### ✨ 実装内容

1. **データ構造の拡張と移行処理**
   - 新しいフィールド追加: `visitedAt`, `createdAt`, `editedAt`, `menu`, `memo`, `photos`
   - 後方互換性を確保: 既存データの `date` → `visitedAt` への自動移行

2. **保存処理の実装**
   - 訪問日・メニュー・メモの編集
   - localStorage への保存処理
   - 保存後の再レンダリング

3. **バリデーション機能**
   - 日付: 必須、未来の日付は選択不可
   - メニュー: 最大100文字
   - メモ: 最大500文字

4. **トースト通知**
   - 保存成功時にメッセージ表示

5. **Phase 1-B-1 レビュー指摘事項の修正**
   - body overflow の正しい復元
   - フォーカスの復元
   - フォーカストラップのガード追加

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)