### PR TITLE
fix: CSP違反の修正 - インラインスタイルをCSSクラスに移行

### DIFF
--- a/assets/css/logs.css
+++ b/assets/css/logs.css
@@ -481,6 +481,40 @@ body {
     outline-offset: 2px;
 }
 
+/* トースト通知 */
+.toast-notification {
+    position: fixed;
+    bottom: 32px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #4caf50;
+    color: white;
+    padding: 12px 24px;
+    border-radius: 6px;
+    z-index: 3000;
+    animation: fadeInOut 2s ease-in-out;
+}
+
+/* トースト通知のアニメーション */
+@keyframes fadeInOut {
+    0% {
+        opacity: 0;
+        transform: translateX(-50%) translateY(20px);
+    }
+    20% {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+    }
+    80% {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+    }
+    100% {
+        opacity: 0;
+        transform: translateX(-50%) translateY(-20px);
+    }
+}
+
 /* レスポンシブ対応 */
 @media (max-width: 600px) {
     .header h1 {

--- a/assets/js/logs.js
+++ b/assets/js/logs.js
@@ -306,8 +306,111 @@ function handleFocusTrap(e) {
     }
 }
 
-// 保存処理（Phase 1-B-2 で実装予定）
+// 保存処理
 function saveEditedLog() {
-    console.log('保存処理は Phase 1-B-2 で実装します');
-    closeEditModal();
+    if (!currentEditingLog) {
+        console.error('編集中のログが見つかりません');
+        return;
+    }
+
+    // 入力値を取得
+    const visitedAt = document.getElementById('modalVisitedAt').value;
+    const menu = document.getElementById('modalMenu').value;
+    const memo = document.getElementById('modalMemo').value;
+
+    // バリデーション
+    if (!validateEditInput(visitedAt, menu, memo)) {
+        return;
+    }
+
+    // データ更新
+    const placeId = currentEditingLog.placeId || currentEditingLog.id || currentEditingLog.place_id;
+    const logIndex = visits.findIndex(l => (l.placeId || l.id || l.place_id) === placeId);
+
+    if (logIndex === -1) {
+        console.error('ログが見つかりません');
+        return;
+    }
+
+    // 更新内容を適用
+    visits[logIndex] = {
+        ...visits[logIndex],
+        visitedAt: visitedAt,
+        menu: menu.trim(),
+        memo: memo.trim(),
+        editedAt: new Date().toISOString()
+    };
+
+    // localStorageに保存
+    try {
+        const storageKey = (typeof Config !== 'undefined' && Config.storageKeys && Config.storageKeys.curryLogs)
+            ? Config.storageKeys.curryLogs
+            : 'curryLogs';
+        localStorage.setItem(storageKey, JSON.stringify(visits));
+        console.log('[Save] ログを保存しました', visits[logIndex]);
+
+        // モーダルを閉じる
+        closeEditModal();
+
+        // ログページを再レンダリング
+        displayLogs();
+
+        // 成功メッセージ
+        showSaveSuccessMessage();
+
+    } catch (error) {
+        console.error('[Save] 保存エラー:', error);
+        alert('保存に失敗しました。容量制限を超えている可能性があります。');
+    }
+}
+
+// 入力値のバリデーション
+function validateEditInput(visitedAt, menu, memo) {
+    // 訪問日のチェック
+    if (!visitedAt) {
+        alert('訪問日を入力してください');
+        return false;
+    }
+
+    // 未来の日付チェック
+    const today = new Date().toISOString().split('T')[0];
+    if (visitedAt > today) {
+        alert('未来の日付は選択できません');
+        return false;
+    }
+
+    // メニューの文字数制限（100文字）
+    if (menu.length > 100) {
+        alert('メニューは100文字以内で入力してください');
+        return false;
+    }
+
+    // メモの文字数制限（500文字）
+    if (memo.length > 500) {
+        alert('メモは500文字以内で入力してください');
+        return false;
+    }
+
+    return true;
+}
+
+// 保存成功メッセージを表示
+function showSaveSuccessMessage() {
+    // 既存のトーストを削除（重複防止）
+    const existingToast = document.querySelector('.toast-notification');
+    if (existingToast) {
+        existingToast.remove();
+    }
+
+    // トースト通知を作成
+    const toast = document.createElement('div');
+    toast.className = 'toast-notification';  // CSSクラスを使用
+    toast.textContent = '保存しました ✓';
+
+    document.body.appendChild(toast);
+
+    // 2秒後に削除
+    setTimeout(() => {
+        toast.remove();
+    }, 2000);
 }


### PR DESCRIPTION
### 🎯 概要

Phase 1-B-2 のCSP違反を修正しました。トースト通知のインラインスタイルをCSSクラスに移行し、CSPポリシーに準拠しました。

### ✨ 変更内容

- トースト通知のインラインスタイルを削除し、`.toast-notification` CSSクラスを追加
- `showSaveSuccessMessage()` 関数をCSP準拠で実装
- 重複防止のため既存トーストを削除する処理を追加
- `saveEditedLog()` および `validateEditInput()` 関数を実装

### ✅ 完了基準

- ✅ インラインスタイルが削除されている
- ✅ .toast-notification CSSクラスが使用されている
- ✅ 既存のトーストが削除されてから新しいトーストが表示される（重複防止）
- ✅ トースト通知が正しく表示される

Closes #100

---

🤖 Generated with [Claude Code](https://claude.ai/code)