### PR TITLE
feat: Add log sorting functionality

### DIFF
--- a/assets/css/logs.css
+++ b/assets/css/logs.css
@@ -43,6 +43,36 @@ body {
     margin: 4px 0;
 }
 
+/* 並び替えコントロール */
+.sort-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0 auto 16px;
+    max-width: 800px;
+    padding: 0 15px;
+}
+
+.sort-dropdown {
+    padding: 8px 12px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 14px;
+    background-color: white;
+    cursor: pointer;
+    transition: border-color 0.2s;
+}
+
+.sort-dropdown:hover {
+    border-color: #FF8C00;
+}
+
+.sort-dropdown:focus {
+    outline: none;
+    border-color: #ff6b35;
+    box-shadow: 0 0 0 3px rgba(255, 107, 53, 0.1);
+}
+
 /* コンテナ */
 .container {
     flex: 1;

--- a/assets/js/logs.js
+++ b/assets/js/logs.js
@@ -59,6 +59,84 @@ function loadVisits() {
     }
 }
 
+/**
+ * ログデータをソートする
+ * @param {Array} logs - ログデータの配列
+ * @param {string} sortType - ソートタイプ
+ * @returns {Array} ソート済みのログデータ
+ */
+function sortLogs(logs, sortType) {
+    const sortedLogs = [...logs]; // 元の配列を変更しないようコピー
+
+    switch (sortType) {
+        case 'date-desc': // 日付順（新→旧）
+            return sortedLogs.sort((a, b) => {
+                const dateA = a.visitedAt || a.createdAt || a.date || '';
+                const dateB = b.visitedAt || b.createdAt || b.date || '';
+                return dateB.localeCompare(dateA);
+            });
+
+        case 'date-asc': // 日付順（旧→新）
+            return sortedLogs.sort((a, b) => {
+                const dateA = a.visitedAt || a.createdAt || a.date || '';
+                const dateB = b.visitedAt || b.createdAt || b.date || '';
+                return dateA.localeCompare(dateB);
+            });
+
+        case 'region': // 地域別（都道府県）
+            return sortedLogs.sort((a, b) => {
+                const prefA = extractPrefecture(a.address || '');
+                const prefB = extractPrefecture(b.address || '');
+                return prefA.localeCompare(prefB, 'ja');
+            });
+
+        case 'visit-count': // 再訪回数順
+            return sortedLogs.sort((a, b) => {
+                const countA = countVisits(logs, a.name);
+                const countB = countVisits(logs, b.name);
+                return countB - countA; // 多い順
+            });
+
+        default:
+            return sortedLogs;
+    }
+}
+
+/**
+ * 住所から都道府県を抽出
+ * @param {string} address - 住所文字列
+ * @returns {string} 都道府県名
+ */
+function extractPrefecture(address) {
+    const prefectures = [
+        '北海道', '青森県', '岩手県', '宮城県', '秋田県', '山形県', '福島県',
+        '茨城県', '栃木県', '群馬県', '埼玉県', '千葉県', '東京都', '神奈川県',
+        '新潟県', '富山県', '石川県', '福井県', '山梨県', '長野県',
+        '岐阜県', '静岡県', '愛知県', '三重県',
+        '滋賀県', '京都府', '大阪府', '兵庫県', '奈良県', '和歌山県',
+        '鳥取県', '島根県', '岡山県', '広島県', '山口県',
+        '徳島県', '香川県', '愛媛県', '高知県',
+        '福岡県', '佐賀県', '長崎県', '熊本県', '大分県', '宮崎県', '鹿児島県', '沖縄県'
+    ];
+
+    for (const pref of prefectures) {
+        if (address.includes(pref)) {
+            return pref;
+        }
+    }
+    return 'その他';
+}
+
+/**
+ * 同じ店舗の訪問回数をカウント
+ * @param {Array} logs - 全ログデータ
+ * @param {string} storeName - 店舗名
+ * @returns {number} 訪問回数
+ */
+function countVisits(logs, storeName) {
+    return logs.filter(log => log.name === storeName).length;
+}
+
 // ログを表示
 function displayLogs() {
     const logsContainer = document.getElementById('logsContainer');
@@ -81,12 +159,17 @@ function displayLogs() {
         return;
     }
 
-    // 訪問日でソート（新→旧）
-    const sortedVisits = [...visits].sort((a, b) => {
-        const dateA = a.visitedAt || a.createdAt || a.date || '';
-        const dateB = b.visitedAt || b.createdAt || b.date || '';
-        return dateB.localeCompare(dateA);
-    });
+    // 並び替え設定を取得（デフォルト: date-desc）
+    const sortType = localStorage.getItem('sortType') || 'date-desc';
+
+    // ソート実行
+    const sortedVisits = sortLogs(visits, sortType);
+
+    // ドロップダウンの選択状態を復元
+    const sortSelect = document.getElementById('sortSelect');
+    if (sortSelect) {
+        sortSelect.value = sortType;
+    }
 
     // 月ごとにグループ化
     const groupedByMonth = groupByMonth(sortedVisits);
@@ -233,6 +316,18 @@ function setupModalListeners() {
     const modalSave = document.getElementById('modalSave');
     if (modalSave) {
         modalSave.addEventListener('click', saveEditedLog);
+    }
+
+    // 並び替えドロップダウンのイベントリスナー
+    const sortSelect = document.getElementById('sortSelect');
+    if (sortSelect) {
+        sortSelect.addEventListener('change', (e) => {
+            const sortType = e.target.value;
+            // 選択した並び順を保存
+            localStorage.setItem('sortType', sortType);
+            // ログを再表示
+            displayLogs();
+        });
     }
 }
 

--- a/logs.html
+++ b/logs.html
@@ -49,6 +49,17 @@
         </button>
     </div>
 
+    <!-- 並び替えコントロール -->
+    <div class="sort-controls">
+        <label for="sortSelect">並び替え:</label>
+        <select id="sortSelect" class="sort-dropdown">
+            <option value="date-desc" selected>日付順（新→旧）</option>
+            <option value="date-asc">日付順（旧→新）</option>
+            <option value="region">地域別</option>
+            <option value="visit-count">再訪回数順</option>
+        </select>
+    </div>
+
     <!-- メニューオーバーレイ -->
     <div class="menu-overlay" id="menuOverlay" aria-hidden="true"></div>
 


### PR DESCRIPTION
## Summary

Implements Phase 1-B-4: Log list sorting feature

### Changes

- Add sorting dropdown UI to logs page
- Implement 4 sort types: date-desc, date-asc, region, visit-count
- Add prefecture extraction logic for region sorting
- Save sort preference to localStorage
- Add CSS styling for sort controls

### Testing

- Date sorting (newest→oldest) works as default
- Date sorting (oldest→newest) reverses order
- Region sorting groups by prefecture alphabetically
- Visit count sorting shows most visited stores first
- Sort preference persists across page reloads
- Sort preference maintained after edit/delete operations

Closes #110

Generated with [Claude Code](https://claude.ai/code)