### PR TITLE
feat: Add log sorting functionality with improvements

### DIFF
--- a/assets/css/logs.css
+++ b/assets/css/logs.css
@@ -43,6 +43,43 @@ body {
     margin: 4px 0;
 }
 
+/* 並び替えコントロール */
+.sort-controls {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    max-width: 800px;
+    width: 100%;
+    margin: 16px auto 0 auto;
+    padding: 0 15px;
+}
+
+.sort-controls label {
+    font-size: 14px;
+    color: #3A2A0A;
+    font-weight: 600;
+}
+
+.sort-dropdown {
+    padding: 8px 12px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    font-size: 14px;
+    background-color: white;
+    cursor: pointer;
+    transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.sort-dropdown:hover {
+    border-color: #FF8C00;
+}
+
+.sort-dropdown:focus {
+    outline: none;
+    border-color: #FF8C00;
+    box-shadow: 0 0 0 3px rgba(255, 140, 0, 0.1);
+}
+
 /* コンテナ */
 .container {
     flex: 1;

--- a/assets/js/logs.js
+++ b/assets/js/logs.js
@@ -3,6 +3,22 @@
 // Config フォールバック
 const APP_NAME = (typeof Config !== 'undefined' && Config.APP_NAME) ? Config.APP_NAME : 'セカカレ';
 
+/**
+ * 日本の都道府県リスト
+ * 地域別ソートで使用
+ */
+const PREFECTURES = [
+    '北海道',
+    '青森県', '岩手県', '宮城県', '秋田県', '山形県', '福島県',
+    '茨城県', '栃木県', '群馬県', '埼玉県', '千葉県', '東京都', '神奈川県',
+    '新潟県', '富山県', '石川県', '福井県', '山梨県', '長野県',
+    '岐阜県', '静岡県', '愛知県', '三重県',
+    '滋賀県', '京都府', '大阪府', '兵庫県', '奈良県', '和歌山県',
+    '鳥取県', '島根県', '岡山県', '広島県', '山口県',
+    '徳島県', '香川県', '愛媛県', '高知県',
+    '福岡県', '佐賀県', '長崎県', '熊本県', '大分県', '宮崎県', '鹿児島県', '沖縄県'
+];
+
 // localStorageから訪問履歴を読み込み
 let visits = [];
 
@@ -12,6 +28,70 @@ let currentEditingLog = null;
 let focusableElements = [];
 let firstFocusableElement = null;
 let lastFocusableElement = null;
+
+/**
+ * ログデータをソートする
+ * @param {Array} logs - ログデータの配列
+ * @param {string} sortType - ソートタイプ
+ * @returns {Array} ソート済みのログデータ
+ */
+function sortLogs(logs, sortType) {
+    const sortedLogs = [...logs]; // 元の配列を変更しないようコピー
+
+    switch (sortType) {
+        case 'date-desc': // 日付順（新→旧）
+            return sortedLogs.sort((a, b) => {
+                const dateA = a.visitedAt || a.createdAt || a.date || '';
+                const dateB = b.visitedAt || b.createdAt || b.date || '';
+                return dateB.localeCompare(dateA);
+            });
+
+        case 'date-asc': // 日付順（旧→新）
+            return sortedLogs.sort((a, b) => {
+                const dateA = a.visitedAt || a.createdAt || a.date || '';
+                const dateB = b.visitedAt || b.createdAt || b.date || '';
+                return dateA.localeCompare(dateB);
+            });
+
+        case 'region': // 地域別（都道府県）
+            return sortedLogs.sort((a, b) => {
+                const prefA = extractPrefecture(a.address || '');
+                const prefB = extractPrefecture(b.address || '');
+                return prefA.localeCompare(prefB, 'ja');
+            });
+
+        case 'visit-count': // 再訪回数順
+            // 事前に訪問回数をカウント（O(n)）
+            const visitCountMap = new Map();
+            logs.forEach(log => {
+                const name = log.name;
+                visitCountMap.set(name, (visitCountMap.get(name) || 0) + 1);
+            });
+
+            return sortedLogs.sort((a, b) => {
+                const countA = visitCountMap.get(a.name) || 0;
+                const countB = visitCountMap.get(b.name) || 0;
+                return countB - countA;
+            });
+
+        default:
+            return sortedLogs;
+    }
+}
+
+/**
+ * 住所から都道府県を抽出
+ * @param {string} address - 住所文字列
+ * @returns {string} 都道府県名
+ */
+function extractPrefecture(address) {
+    for (const pref of PREFECTURES) {
+        if (address.includes(pref)) {
+            return pref;
+        }
+    }
+    return 'その他';
+}
 
 // ページ読み込み時の初期化
 document.addEventListener('DOMContentLoaded', function() {
@@ -25,6 +105,7 @@ function initLogsPage() {
     updateHeader();
     setupModalElements();
     setupModalListeners();
+    setupSortListener();
 }
 
 // 訪問履歴を読み込み（後方互換性あり）
@@ -81,12 +162,22 @@ function displayLogs() {
         return;
     }
 
-    // 訪問日でソート（新→旧）
-    const sortedVisits = [...visits].sort((a, b) => {
-        const dateA = a.visitedAt || a.createdAt || a.date || '';
-        const dateB = b.visitedAt || b.createdAt || b.date || '';
-        return dateB.localeCompare(dateA);
-    });
+    // 並び替え設定を取得（デフォルト: date-desc）
+    let sortType = 'date-desc';
+    try {
+        sortType = localStorage.getItem('sortType') || 'date-desc';
+    } catch (e) {
+        console.warn('localStorage unavailable:', e);
+    }
+
+    // ソート実行
+    const sortedVisits = sortLogs(visits, sortType);
+
+    // ドロップダウンの選択状態を復元
+    const sortSelect = document.getElementById('sortSelect');
+    if (sortSelect) {
+        sortSelect.value = sortType;
+    }
 
     // 月ごとにグループ化
     const groupedByMonth = groupByMonth(sortedVisits);
@@ -233,6 +324,24 @@ function setupModalListeners() {
     const modalSave = document.getElementById('modalSave');
     if (modalSave) {
         modalSave.addEventListener('click', saveEditedLog);
+    }
+}
+
+// 並び替えドロップダウンのイベントリスナー設定
+function setupSortListener() {
+    const sortSelect = document.getElementById('sortSelect');
+    if (sortSelect) {
+        sortSelect.addEventListener('change', (e) => {
+            const sortType = e.target.value;
+            // 選択した並び順を保存
+            try {
+                localStorage.setItem('sortType', sortType);
+            } catch (error) {
+                console.warn('localStorage save failed:', error);
+            }
+            // ログを再表示
+            displayLogs();
+        });
     }
 }
 

--- a/logs.html
+++ b/logs.html
@@ -49,6 +49,17 @@
         </button>
     </div>
 
+    <!-- 並び替えコントロール -->
+    <div class="sort-controls">
+        <label for="sortSelect">並び替え:</label>
+        <select id="sortSelect" class="sort-dropdown" aria-label="ログの並び替え順を選択">
+            <option value="date-desc" selected>日付順（新→旧）</option>
+            <option value="date-asc">日付順（旧→新）</option>
+            <option value="region">地域別</option>
+            <option value="visit-count">再訪回数順</option>
+        </select>
+    </div>
+
     <!-- メニューオーバーレイ -->
     <div class="menu-overlay" id="menuOverlay" aria-hidden="true"></div>
 


### PR DESCRIPTION
## Summary

Implements Phase 1-B-4: Log list sorting feature with all requested improvements.

### Changes

- Add sorting dropdown UI with 4 sort types (date-desc, date-asc, region, visit-count)
- Extract PREFECTURES constant (all 47 prefectures) for maintainability
- Add aria-label to select element for accessibility
- Implement sortLogs() with performance-optimized visit-count (uses Map for O(n log n))
- Implement extractPrefecture() using PREFECTURES constant
- Add localStorage error handling with try-catch for private browsing support
- Save sort preference to localStorage
- Restore sort preference on page load
- Add CSS styling for sort controls with orange theme

### Features

✓ Date sorting (newest first) - default
✓ Date sorting (oldest first)
✓ Region sorting (by prefecture, alphabetically in Japanese)
✓ Visit count sorting (most visited stores first)
✓ Sort preference persists across page reloads
✓ Sort preference maintained after editing/deleting logs
✓ Accessibility support with aria-label
✓ Private browsing mode compatibility

### Improvements Included

1. **localStorage Error Handling**: Try-catch blocks for private browsing compatibility
2. **PREFECTURES Constant**: All 47 prefectures extracted for maintainability
3. **Accessibility**: aria-label added to select element
4. **Performance**: Visit-count sorting optimized to O(n log n) using Map

Closes #110

🤖 Generated with [Claude Code](https://claude.ai/code)