### PR TITLE
Fix: Display regional grouping correctly when regional sort is selected

### DIFF
--- a/assets/css/logs.css
+++ b/assets/css/logs.css
@@ -108,6 +108,20 @@ body {
     border-bottom: 2px solid #ff8c00;
 }
 
+/* 地域グループのスタイル */
+.region-group {
+    margin-bottom: 32px;
+}
+
+.region-header {
+    font-size: 20px;
+    font-weight: bold;
+    color: #FF8C00;
+    margin-bottom: 16px;
+    padding-bottom: 8px;
+    border-bottom: 2px solid #FF8C00;
+}
+
 /* ログカード */
 .log-card {
     background: #FFFFFF;


### PR DESCRIPTION
## 🐛 Problem

When regional sort was selected, logs were still grouped by month instead of by prefecture, causing logs from the same prefecture to be scattered across different month groups.

## 🔧 Changes

### JavaScript (`assets/js/logs.js`)
- Refactored `displayLogs()` to branch based on `sortType`
- Added `displayLogsByRegion()` for prefecture-based grouping
- Added `displayLogsByDate()` for month-based grouping (existing behavior)

### CSS (`assets/css/logs.css`)
- Added `.region-group` and `.region-header` styles

## ✅ Expected Behavior

- **Regional sort**: Groups by prefecture, all logs from same prefecture together
- **Date sorts**: Groups by month (original behavior)
- **Visit count sort**: Groups by month (original behavior)
- Edit/delete buttons work correctly
- Responsive design maintained

Fixes #114

---

Generated with [Claude Code](https://claude.ai/code)