### PR TITLE
Phase 1-B-5: Add Content Security Policy (CSP) Headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    
+    <!-- Content Security Policy -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https://maps.googleapis.com https://*.gstatic.com https://www.googletagmanager.com; script-src 'self' 'unsafe-inline' https://maps.googleapis.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://maps.googleapis.com https://www.google-analytics.com https://www.googletagmanager.com; font-src 'self' data:; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self';">
+    
     <title>セカカレ - あなたのカレー体験を記録しよう</title>
     <meta name="description" content="食べたカレーを地図上に記録して、あなただけのカレーマップを作成。全国のカレー店を発見して、カレー巡りを楽しもう！">
     <meta name="keywords" content="カレー,グルメ,地図,ログ,記録,レストラン">

--- a/logs.html
+++ b/logs.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    
+    <!-- Content Security Policy -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https://maps.googleapis.com https://*.gstatic.com; script-src 'self' 'unsafe-inline' https://maps.googleapis.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://maps.googleapis.com; font-src 'self' data:; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self';">
+    
     <title>🍛 ログ - セカカレ</title>
     <meta name="description" content="あなたのカレー旅ログを時系列で振り返る">
 


### PR DESCRIPTION
## 🔒 概要

Phase 1-B-5: Content Security Policy (CSP) ヘッダーをHTMLファイルに追加しました。

## ✨ 実装内容

### CSP設定の追加
- `index.html` にCSP metaタグ追加
- `logs.html` にCSP metaタグ追加

### CSPディレクティブ

```http
Content-Security-Policy:
  default-src 'self';
  img-src 'self' data: https://maps.googleapis.com https://*.gstatic.com https://www.googletagmanager.com;
  script-src 'self' 'unsafe-inline' https://maps.googleapis.com https://www.googletagmanager.com;
  style-src 'self' 'unsafe-inline';
  connect-src 'self' https://maps.googleapis.com https://www.google-analytics.com https://www.googletagmanager.com;
  font-src 'self' data:;
  frame-src 'none';
  object-src 'none';
  base-uri 'self';
  form-action 'self';
```

### セキュリティ強化ポイント

1. **デフォルトで同一オリジン制限**: `default-src 'self'`
2. **Base64画像対応**: `img-src` に `data:` を許可（写真アップロード機能）
3. **Google Maps API許可**: 必要なドメインのみホワイトリスト
4. **フレーム・オブジェクト禁止**: `frame-src 'none'`, `object-src 'none'`

### 注意事項

- `'unsafe-inline'` を使用（インラインスクリプト・スタイルのため）
  - 将来的には nonce または hash ベースのCSPに移行推奨

## ✅ テスト項目

- [x] index.htmlが正常に表示される
- [x] logs.htmlが正常に表示される
- [x] Google Maps APIが動作する
- [x] 写真アップロード（data: URL）が機能する
- [x] Google Analyticsが動作する
- [x] CSP違反エラーが出ない

## 🎯 セキュリティ効果

- XSS攻撃の追加防御層
- ブラウザレベルでのセキュリティ強化
- 予期しない外部リソースの読み込み防止

## 📚 参考資料

- [MDN: Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
- [OWASP: CSP Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Content_Security_Policy_Cheat_Sheet.html)

---

Closes #119