### PR TITLE
🚨 Critical: Fix CSP blocking Google Fonts and Maps API

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- Content Security Policy -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https://maps.googleapis.com https://*.gstatic.com https://www.googletagmanager.com; script-src 'self' 'unsafe-inline' https://maps.googleapis.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://maps.googleapis.com https://www.google-analytics.com https://www.googletagmanager.com; font-src 'self' data:; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https://maps.googleapis.com https://*.gstatic.com https://www.googletagmanager.com; script-src 'self' 'unsafe-inline' https://maps.googleapis.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' https://maps.googleapis.com https://places.googleapis.com https://www.google-analytics.com https://www.googletagmanager.com; font-src 'self' data: https://fonts.gstatic.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self';">
     
     <title>セカカレ - あなたのカレー体験を記録しよう</title>
     <meta name="description" content="食べたカレーを地図上に記録して、あなただけのカレーマップを作成。全国のカレー店を発見して、カレー巡りを楽しもう！">

--- a/logs.html
+++ b/logs.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- Content Security Policy -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https://maps.googleapis.com https://*.gstatic.com; script-src 'self' 'unsafe-inline' https://maps.googleapis.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://maps.googleapis.com; font-src 'self' data:; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https://maps.googleapis.com https://*.gstatic.com; script-src 'self' 'unsafe-inline' https://maps.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' https://maps.googleapis.com https://places.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self';">
     
     <title>🍛 ログ - セカカレ</title>
     <meta name="description" content="あなたのカレー旅ログを時系列で振り返る">


### PR DESCRIPTION
## 🚨 Critical Bug Fix

CSP設定が厳しすぎて、Google FontsとMaps APIがブロックされていた問題を修正しました。

## 🐛 問題
PR #121のCSP追加により、以下がブロックされていました：
- Google Fontsのスタイルシート
- Google Maps Places API
- フォントファイルの読み込み

結果、カレー店が地図に表示されなくなりました。

## ✅ 修正内容

### CSPディレクティブに追加
- `style-src`: `https://fonts.googleapis.com` 追加
- `font-src`: `https://fonts.gstatic.com` 追加
- `connect-src`: `https://places.googleapis.com` 追加

### 修正後のCSP
```http
style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
font-src 'self' data: https://fonts.gstatic.com;
connect-src 'self' https://maps.googleapis.com https://places.googleapis.com ...;
```

## 🧪 テスト
- [x] 地図が正常に表示される
- [x] カレー店が検索できる
- [x] Google Fontsが読み込まれる
- [x] CSP違反エラーが出ない

---

**優先度**: Critical（即座マージ推奨）