### PR TITLE
fix: Photo validation error - correct variable name in isValidBase64Image

### DIFF
--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -31,7 +31,7 @@ function escapeHtml(str) {
  * @returns {boolean} 妥当な場合true
  */
 function isValidBase64Image(data) {
-    if (typeof str !== 'string') return false;
+    if (typeof data !== 'string') return false;
     
     // Base64画像データの形式チェック
     const base64Pattern = /^data:image\/(jpeg|jpg|png|webp);base64,/i;


### PR DESCRIPTION
## 🐛 Bug Fix

写真アップロード機能で「画像データの検証に失敗しました」エラーが発生していた問題を修正しました。

## 問題

`isValidBase64Image()` 関数の36行目で、パラメータ名が `data` なのに `typeof str` をチェックしていたため、常に `false` を返していました。

### 修正前
```javascript
function isValidBase64Image(data) {
    if (typeof str !== 'string') return false;  // ❌ 'str' is undefined
    // ...
}
```

### 修正後
```javascript
function isValidBase64Image(data) {
    if (typeof data !== 'string') return false;  // ✅ Correct parameter name
    // ...
}
```

## 影響

この関数は `sanitizeImageData()` から呼ばれ、写真の保存時に必ず実行されます。バグにより全ての画像が検証失敗していました。

## テスト

修正後、以下が正常動作するはずです：
- ✅ 写真の選択
- ✅ 画像のプレビュー
- ✅ 画像の圧縮
- ✅ Base64検証の通過
- ✅ 写真の保存

---

**優先度**: High（写真機能が完全に使用不可だったため）