### PR TITLE
fix: Add character limit with ellipsis to ticker text

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -209,6 +209,8 @@ body {
     display: flex;
     align-items: center;
     gap: 10px;
+    width: 100%;
+    min-width: 0; /* flexアイテムのテキスト省略に必要 */
 }
 
 .ticker-item.active {
@@ -239,6 +241,11 @@ body {
     text-decoration: none;
     font-size: 14px;
     transition: color 0.2s;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+    min-width: 0;
 }
 
 .ticker-item a:hover {


### PR DESCRIPTION
ティッカーテキストが長い場合に2行になってしまう問題を修正。
CSSに以下の変更を追加:
- white-space: nowrap でテキストの折り返しを防止
- text-overflow: ellipsis で超過分を「…」で表示
- overflow: hidden と適切なflex設定で1行表示を保証

これにより、ティッカーが常に1行で表示され、UIの一貫性が保たれます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)