### PR TITLE
ヒートマップをGoogle HeatmapLayerに移行

### DIFF
--- a/assets/js/config.template.js
+++ b/assets/js/config.template.js
@@ -37,8 +37,10 @@ const Config = {
         heatmap: {
             minOpacity: 0.3,
             maxOpacity: 0.8,
-            baseRadius: 100,
-            radiusIncrement: 50
+            baseRadius: 100,  // 旧実装用（将来削除予定）
+            radiusIncrement: 50,  // 旧実装用（将来削除予定）
+            minRadiusPx: 8,   // zoom 6（広域）での半径（ピクセル）
+            maxRadiusPx: 40   // zoom 18（近接）での半径（ピクセル）
         }
     },
 


### PR DESCRIPTION
## 🎯 概要

Circle APIベースのヒートマップをGoogle Maps公式のHeatmapLayerに移行し、ズーム依存の半径調整を実装しました。

## ✨ 変更内容

- Google Maps Visualization Libraryを追加
- Circle APIベースの実装をHeatmapLayerに置き換え
- ズーム依存の半径調整機能を実装（zoom 6-18で8-40px）
- 訪問回数に応じた重み付けを適用

## 🚀 期待される効果

- 広域表示（zoom 6-12）で孤立点が見やすくなる
- 半円問題の解消
- ズームに応じた自動半径調整

Resolves #133

---

Generated with [Claude Code](https://claude.ai/code)) | [View branch](https://github.com/masahito-hub/sekakare/tree/claude/issue-133-20251103-0656) | [View job run](https://github.com/masahito-hub/sekakare/actions/runs/19026362492