### PR TITLE
Google HeatmapLayerへの移行（Critical Fixes適用版）

### DIFF
--- a/assets/js/config.template.js
+++ b/assets/js/config.template.js
@@ -38,7 +38,9 @@ const Config = {
             minOpacity: 0.3,
             maxOpacity: 0.8,
             baseRadius: 100,
-            radiusIncrement: 50
+            radiusIncrement: 50,
+            minRadiusPx: 8,   // zoom 6（広域）での半径（ピクセル）
+            maxRadiusPx: 40   // zoom 18（近接）での半径（ピクセル）
         }
     },
 


### PR DESCRIPTION
## 🎯 概要

Circle APIベースのヒートマップをGoogle Maps公式のHeatmapLayerに移行し、ズーム依存の半径調整を実装しました。

## ✨ 変更内容

### 1. HeatmapLayer実装
- Circle APIベースの実装をGoogle Maps公式HeatmapLayerに置き換え
- 訪問回数を重み付け（weight）として使用
- ズーム6-18で半径8-40pxに線形補間

### 2. 🔧 Critical Fix 1: Visualization Library未ロード時のエラーハンドリング
- `google.maps.visualization`の存在チェックを追加
- 未ロード時に適切なエラーメッセージを表示

### 3. 🔧 Critical Fix 2: Event Listenerメモリリーク対策
- `zoomListenerAdded`フラグをグローバルスコープに追加
- `zoom_changed`リスナーが1回だけ登録されるよう制御
- `displayHeatmap()`を複数回呼び出しても重複しない

### 4. Google Maps Visualization Libraryの追加
- `libraries=places,marker,visualization`

### 5. 設定の追加
- `minRadiusPx: 8` - 広域表示での最小半径
- `maxRadiusPx: 40` - 近接表示での最大半径

## 🚀 期待される効果

✅ 孤立点の可視性向上 - zoom 6-12で最小8pxの半径により見やすくなりました
✅ 半円問題の解消 - Google公式APIにより完全な円形を保証
✅ ズーム対応 - 6-18のズームで8〜40pxの間で滑らかに変化
✅ メモリリーク防止 - Event Listenerが重複登録されない
✅ エラーハンドリング - Visualization Library未ロード時に適切に処理

Resolves #133

---

Generated with [Claude Code](https://claude.ai/code)