### PR TITLE
ヒートマップのUX改善3点セット（広域視認性・カレー色・自動検索制御)

### DIFF
--- a/assets/js/config.template.js
+++ b/assets/js/config.template.js
@@ -39,7 +39,7 @@ const Config = {
             maxOpacity: 0.8,
             baseRadius: 100,
             radiusIncrement: 50,
-            minRadiusPx: 8,   // zoom 6（広域）での半径（ピクセル）
+            minRadiusPx: 18,  // zoom 6（広域）での半径（ピクセル） - 広域視認性向上のため8→18に変更
             maxRadiusPx: 40   // zoom 18（近接）での半径（ピクセル）
         }
     },


### PR DESCRIPTION
## 🎯 概要

ヒートマップのUXを3つ改善しました：

1. **広域視認性の向上** - zoom 6での最小半径を8px→18pxに変更
2. **カレー色グラデーション** - 黄→橙→茶のカレー色を適用
3. **自動検索制御** - zoom 12以下では自動検索を無効化

Fixes #136

## ✅ 変更内容

- `assets/js/config.template.js`: minRadiusPxを8→18に変更
- `assets/js/app.js`: カレー色グラデーション定義を追加
- `assets/js/app.js`: 自動検索のズーム制御（ヒステリシス付き）を実装

🤖 Generated with [Claude Code](https://claude.ai/code)