### PR TITLE
Phase 2: ヒートマップUX追加調整（広域視認性・塗り感・非線形スケーリング)

### DIFF
--- a/assets/js/config.template.js
+++ b/assets/js/config.template.js
@@ -39,8 +39,8 @@ const Config = {
             maxOpacity: 0.8,
             baseRadius: 100,
             radiusIncrement: 50,
-            minRadiusPx: 18,  // zoom 6（広域）での半径（ピクセル） - 広域視認性向上のため8→18に変更
-            maxRadiusPx: 40   // zoom 18（近接）での半径（ピクセル）
+            minRadiusPx: 35,  // zoom 6（広域）での半径（ピクセル） - Phase 2: 18→35に変更（広域視認性さらに向上）
+            maxRadiusPx: 55   // zoom 18（近接）での半径（ピクセル） - Phase 2: 40→55に変更
         }
     },
 


### PR DESCRIPTION
## 🎯 概要

PR #138のテスト結果を受け、ヒートマップUXをさらに改善しました：

1. **半径設定の大幅引き上げ** - minRadiusPx: 18→35、maxRadiusPx: 40→55
2. **maxIntensityの明示的設定** - 孤立点の視認性向上
3. **minWeight boost** - 最小weight=2を保証
4. **非線形スケーリング** - pow(t, 0.8)で自然な拡大縮小
5. **カレー色グラデーションの微調整** - alpha値引き上げ＋opacity 0.85

Fixes #136

## ✅ 変更内容

- `assets/js/config.template.js`: minRadiusPx 18→35、maxRadiusPx 40→55
- `assets/js/app.js`: maxIntensity: 3を追加
- `assets/js/app.js`: minWeight boost（Math.max(count, 2)）
- `assets/js/app.js`: 非線形getHeatmapRadius()実装
- `assets/js/app.js`: グラデーションalpha値調整＋opacity 0.7→0.85

## 📊 技術的根拠

- **maxIntensity: 3**: weight分布[1-10]で適切な階調
- **minWeight: 2**: 福島エリア（1回訪問）が確実に表示
- **非線形イージング**: 広域を厚め、近接は抑えめ
- **R_MIN: 35, R_MAX: 55**: 「カレー店の訪問エリア」として適切

## 🧪 検証方法

本番環境デプロイ後に以下を確認：

1. zoom 6： 福島の1件が明確に見える
2. zoom 12： 塗り感が改善
3. zoom 18： 過剰なボケがない
4. 全ズームレンジで自然な拡大縮小

🤖 Generated with [Claude Code](https://claude.com/claude-code)