### PR TITLE
fix: 広域表示で自動検索を確実にスキップ

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -178,6 +178,19 @@ function setupAutoSearch() {
                 return;
             }
 
+            // 🔧 追加: 広域表示では自動検索をスキップ
+            if (!autoSearchEnabled) {
+                console.log('🚫 検索スキップ (zoom < 13)');
+
+                // 既存マーカーを削除
+                if (markers && markers.length > 0) {
+                    markers.forEach(marker => marker.setMap(null));
+                    markers = [];
+                    console.log('広域表示モードに切り替え - マーカーをクリア');
+                }
+                return;
+            }
+
             const center = map.getCenter();
             if (center) {
                 console.log('地図移動検出 - 周辺のカレー店を検索中...');


### PR DESCRIPTION
### 🎯 概要

自動検索制御の不具合を修正しました。`autoSearchEnabled` 変数は正しく定義され、`autoSearchCurryShops()` 内にガード句がありましたが、`idle` リスナー内で関数を呼び出す前にチェックする必要がありました。

### ✅ 変更内容

- `assets/js/app.js`: `idle` リスナーに `autoSearchEnabled` チェックを追加
- zoom < 13 では自動検索をスキップし、既存マーカーをクリア
- コンソールログで状態を明示

Fixes #136

🤖 Generated with [Claude Code](https://claude.ai/code)) | [Branch: claude/issue-136-20251109-1313](https://github.com/masahito-hub/sekakare/tree/claude/issue-136-20251109-1313) | [View job run](https://github.com/masahito-hub/sekakare/actions/runs/19209008673