### PR TITLE
feat: FABボタン実装（現在地からカレー追加）+ デフォルトUI非表示

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -838,3 +838,67 @@ body.menu-open {
         width: 100%;
     }
 }
+
+/* ============================================================================
+   FABボタン（カレー追加）
+   ============================================================================ */
+
+.fab-add-curry {
+    position: fixed;
+    bottom: 30px;
+    right: 30px;
+    width: 120px;
+    height: 56px;
+    background: linear-gradient(135deg, #ff6b00 0%, #ff8c00 100%);
+    border: none;
+    border-radius: 28px;
+    box-shadow: 0 4px 12px rgba(255, 107, 0, 0.4);
+    color: white;
+    font-size: 16px;
+    font-weight: bold;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    z-index: 1000;
+    transition: all 0.3s ease;
+}
+
+.fab-add-curry:hover {
+    transform: scale(1.05);
+    box-shadow: 0 6px 16px rgba(255, 107, 0, 0.5);
+}
+
+.fab-add-curry:active {
+    transform: scale(0.95);
+}
+
+.fab-icon {
+    font-size: 24px;
+    line-height: 1;
+}
+
+.fab-text {
+    font-size: 14px;
+}
+
+/* モバイル対応 */
+@media (max-width: 600px) {
+    .fab-add-curry {
+        bottom: 20px;
+        right: 20px;
+        width: 60px;
+        height: 60px;
+        border-radius: 30px;
+    }
+
+    /* モバイルではアイコンのみ表示 */
+    .fab-text {
+        display: none;
+    }
+
+    .fab-icon {
+        font-size: 28px;
+    }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -119,6 +119,13 @@ function createMap(center, zoom) {
         center: center,
         gestureHandling: 'greedy',  // 1本指でのパン操作を可能にする
         mapId: 'sekakare_map',  // Advanced Markers用のMap IDを追加
+
+        // デフォルトUIコントロールを非表示
+        zoomControl: false,           // ズーム±ボタン非表示
+        streetViewControl: false,     // ストリートビュー（黄色い人形）非表示
+        mapTypeControl: false,        // 地図/航空写真切替非表示
+        fullscreenControl: false,     // フルスクリーンボタン非表示
+
         styles: [
             {
                 "featureType": "poi",
@@ -1416,6 +1423,91 @@ function initCustomPoints() {
     setupCustomPointListeners();
     setupCustomPointMapClick();
     displayCustomPointMarkers();
+    setupFABButton();  // FABボタンを初期化
+}
+
+/**
+ * FABボタンの状態をリセット
+ */
+function resetFABButton() {
+    const fabButton = document.getElementById('fabAddCurry');
+    if (fabButton) {
+        fabButton.disabled = false;
+        fabButton.style.opacity = '1';
+    }
+}
+
+/**
+ * FABボタンで現在地からカレーを追加
+ */
+function setupFABButton() {
+    const fabButton = document.getElementById('fabAddCurry');
+    if (!fabButton) return;
+
+    fabButton.addEventListener('click', () => {
+        // 現在地を取得
+        if (navigator.geolocation) {
+            fabButton.disabled = true;
+            fabButton.style.opacity = '0.6';
+
+            navigator.geolocation.getCurrentPosition(
+                (position) => {
+                    const lat = position.coords.latitude;
+                    const lng = position.coords.longitude;
+
+                    // 地図を現在地に移動
+                    map.setCenter({ lat, lng });
+                    map.setZoom(16);
+
+                    // 重複チェック
+                    const duplicateCheck = checkDuplicateNearby(lat, lng);
+                    if (duplicateCheck.isDuplicate) {
+                        const existingName = duplicateCheck.existingPoint
+                            ? escapeHtml(duplicateCheck.existingPoint.name)
+                            : '既存の訪問記録';
+
+                        if (!confirm(`⚠️ 近くに既存の記録があります\n\n「${existingName}」\n\nそれでも追加しますか？`)) {
+                            resetFABButton();
+                            return;
+                        }
+                    }
+
+                    // モーダル表示
+                    showCustomPointModal(lat, lng);
+
+                    resetFABButton();
+                },
+                (error) => {
+                    console.error('現在地取得エラー:', error);
+
+                    // エラー時は地図中心でモーダル表示
+                    const center = map.getCenter();
+                    if (center) {
+                        alert('現在地の取得に失敗しました。\n地図の中心位置でカレーを追加します。');
+                        showCustomPointModal(center.lat(), center.lng());
+                    } else {
+                        alert('位置情報を取得できませんでした。');
+                    }
+
+                    resetFABButton();
+                },
+                {
+                    enableHighAccuracy: false,  // WiFi/セルラーで十分（店舗登録の精度は数十mで問題ない）
+                    timeout: 15000,             // 15秒に延長（モバイル環境考慮）
+                    maximumAge: 30000           // 30秒以内のキャッシュ許容
+                }
+            );
+        } else {
+            // Geolocation非対応時は地図中心でモーダル表示
+            const center = map.getCenter();
+            if (center) {
+                alert('お使いのブラウザは位置情報に対応していません。\n地図の中心位置でカレーを追加します。');
+                showCustomPointModal(center.lat(), center.lng());
+            } else {
+                alert('位置情報を取得できませんでした。');
+            }
+        }
+    });
 }
 
 // createMap関数内でカスタム地点を初期化するよう、既存のcreateMap関数を拡張

--- a/index.html
+++ b/index.html
@@ -121,6 +121,12 @@
     <div class="container">
         <div id="map"></div>
 
+        <!-- FABボタン（カレー追加） -->
+        <button class="fab-add-curry" id="fabAddCurry" aria-label="現在地からカレーを追加">
+            <span class="fab-icon">🍛</span>
+            <span class="fab-text">カレーを追加</span>
+        </button>
+
         <div class="controls">
             <input type="text" class="search-box" placeholder="🔍 店名で検索... (例: スープカレー GARAKU)" id="searchBox">
             <small style="color: #666;">Enterキーで検索</small>


### PR DESCRIPTION
## 🎯 概要

Issue #150 の対応で、FABボタンを実装し、GoogleマップのデフォルトUIコントロールを非表示にしました。

## 📋 変更内容

**セキュリティ修正済み**

- ✅ XSS対策: escapeHtml()で既存地点名をサニタイズ
- ✅ Geolocation設定を最適化（enableHighAccuracy: false, timeout: 15s, maximumAge: 30s）
- ✅ FABボタンリセット処理をresetFABButton()関数に集約

**機能実装**

- ✅ GoogleマップのデフォルトUIコントロール（ズーム、ストリートビュー等）を非表示
- ✅ 画面右下にFABボタン（カレー追加）を追加
- ✅ FABボタンクリックで現在地取得してカスタム地点モーダルを表示
- ✅ 現在地取得失敗時は地図中心位置でモーダル表示
- ✅ モバイルではアイコンのみ、デスクトップではアイコン+テキスト表示
- ✅ ホバー時のスケールアップアニメーション実装

## ✅ 完了条件

- ✅ Googleマップのデフォルトコントロールが非表示
- ✅ FABボタンが画面右下に表示
- ✅ FABボタンタップで現在地取得してモーダル表示
- ✅ 現在地取得失敗時のフォールバック実装
- ✅ モバイル・デスクトップ両対応
- ✅ アニメーション実装
- ✅ 既存機能にデグレなし

Closes #150

---

Generated with [Claude Code](https://claude.ai/claude-code)