### PR TITLE
feat: FABボタン実装（現在地からカレー追加）+ デフォルトUI非表示

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -838,3 +838,67 @@ body.menu-open {
         width: 100%;
     }
 }
+
+/* ============================================================================
+   FABボタン（カレー追加）
+   ============================================================================ */
+
+.fab-add-curry {
+    position: fixed;
+    bottom: 30px;
+    right: 30px;
+    width: 120px;
+    height: 56px;
+    background: linear-gradient(135deg, #ff6b00 0%, #ff8c00 100%);
+    border: none;
+    border-radius: 28px;
+    box-shadow: 0 4px 12px rgba(255, 107, 0, 0.4);
+    color: white;
+    font-size: 16px;
+    font-weight: bold;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    z-index: 1000;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.fab-add-curry:hover {
+    transform: scale(1.05);
+    box-shadow: 0 6px 16px rgba(255, 107, 0, 0.5);
+}
+
+.fab-add-curry:active {
+    transform: scale(0.95);
+}
+
+.fab-icon {
+    font-size: 24px;
+    line-height: 1;
+}
+
+.fab-text {
+    font-size: 14px;
+}
+
+/* モバイル対応 */
+@media (max-width: 600px) {
+    .fab-add-curry {
+        bottom: 20px;
+        right: 20px;
+        width: 60px;
+        height: 60px;
+        border-radius: 30px;
+    }
+
+    /* モバイルではアイコンのみ表示 */
+    .fab-text {
+        display: none;
+    }
+
+    .fab-icon {
+        font-size: 28px;
+    }
+}

--- a/index.html
+++ b/index.html
@@ -121,6 +121,12 @@
     <div class="container">
         <div id="map"></div>
 
+        <!-- FABボタン（カレー追加） -->
+        <button class="fab-add-curry" id="fabAddCurry" aria-label="現在地からカレーを追加">
+            <span class="fab-icon">🍛</span>
+            <span class="fab-text">カレーを追加</span>
+        </button>
+
         <div class="controls">
             <input type="text" class="search-box" placeholder="🔍 店名で検索... (例: スープカレー GARAKU)" id="searchBox">
             <small style="color: #666;">Enterキーで検索</small>


### PR DESCRIPTION
## 🎯 概要

Issue #150 の対応で、FABボタンを実装し、GoogleマップのデフォルトUIコントロールを非表示にしました。

## 🔴 Critical修正

- ✅ XSS対策: `escapeHtml()` を使用して既存地点名をサニタイズ

## 🟡 推奨修正

- ✅ CSS transition最適化: `transform` と `box-shadow` のみ指定
- ✅ Geolocation設定最適化（enableHighAccuracy: false, timeout: 15s, maximumAge: 30s）
- ✅ FABボタンリセット処理を`resetFABButton()`関数に集約

## ✨ 機能実装

- ✅ GoogleマップのデフォルトUIコントロール（ズーム、ストリートビュー等）を非表示
- ✅ 画面右下にFABボタン（カレー追加）を追加
- ✅ FABボタンクリックで現在地取得してカスタム地点モーダルを表示
- ✅ 現在地取得失敗時は地図中心位置でモーダル表示
- ✅ モバイルではアイコンのみ、デスクトップではアイコン+テキスト表示
- ✅ ホバー時のスケールアップアニメーション実装

## ✅ 完了条件

- ✅ Googleマップのデフォルトコントロールが非表示
- ✅ FABボタンが画面右下に表示
- ✅ FABボタンタップで現在地取得してモーダル表示
- ✅ 現在地取得失敗時のフォールバック実装
- ✅ モバイル・デスクトップ両対応
- ✅ アニメーション実装
- ✅ 既存機能にデグレなし

Closes #150

---

Generated with [Claude Code](https://claude.ai/claude-code)