### PR TITLE
Add CSV generation and deployment for ticker data

### DIFF
--- a/ticker-automation/scripts/run_finalize.sh
+++ b/ticker-automation/scripts/run_finalize.sh
@@ -23,27 +23,32 @@ echo "Started at: $(date)"
 echo ""
 
 # リアクション収集
-echo "[1/5] Collecting reactions..."
+echo "[1/6] Collecting reactions..."
 node src/collect_reactions.js
 
 # アーカイブ更新
 echo ""
-echo "[2/5] Updating archive..."
+echo "[2/6] Updating archive..."
 node src/update_archive.js
 
 # ticker.json生成
 echo ""
-echo "[3/5] Generating ticker.json..."
+echo "[3/6] Generating ticker.json..."
 node src/generate_ticker.js
+
+# ticker-data.csv生成
+echo ""
+echo "[4/6] Generating ticker-data.csv..."
+node src/generate_csv.js
 
 # FTPデプロイ
 echo ""
-echo "[4/5] Deploying to Xserver..."
+echo "[5/6] Deploying to Xserver..."
 node src/deploy.js
 
 # 結果通知
 echo ""
-echo "[5/5] Sending result notification..."
+echo "[6/6] Sending result notification..."
 node src/notify_result.js
 
 echo ""

--- a/ticker-automation/src/deploy.js
+++ b/ticker-automation/src/deploy.js
@@ -7,6 +7,7 @@ dotenv.config();
 
 const DATA_DIR = path.join(process.cwd(), 'data');
 const TICKER_FILE = path.join(DATA_DIR, 'ticker.json');
+const CSV_FILE = path.join(DATA_DIR, 'ticker-data.csv');
 
 async function deployWithRetry(maxRetries = 3) {
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -28,8 +29,12 @@ async function deployWithRetry(maxRetries = 3) {
 
       // ticker.jsonをアップロード
       await client.uploadFrom(TICKER_FILE, process.env.FTP_REMOTE_PATH);
+      console.log(`  ✅ Uploaded ticker.json to ${process.env.FTP_REMOTE_PATH}`);
 
-      console.log(`  ✅ Uploaded to ${process.env.FTP_REMOTE_PATH}`);
+      // ticker-data.csvをアップロード
+      const csvRemotePath = process.env.FTP_REMOTE_PATH.replace('ticker.json', 'assets/data/ticker-data.csv');
+      await client.uploadFrom(CSV_FILE, csvRemotePath);
+      console.log(`  ✅ Uploaded ticker-data.csv to ${csvRemotePath}`);
 
       client.close();
       return true;
@@ -50,13 +55,20 @@ async function deployWithRetry(maxRetries = 3) {
 }
 
 async function deploy() {
-  console.log('🚀 Deploying ticker.json to Xserver...');
+  console.log('🚀 Deploying ticker files to Xserver...');
 
   // ticker.jsonの存在確認
   try {
     await fs.access(TICKER_FILE);
   } catch (error) {
     throw new Error('ticker.json not found. Please run generate_ticker.js first.');
+  }
+
+  // ticker-data.csvの存在確認
+  try {
+    await fs.access(CSV_FILE);
+  } catch (error) {
+    throw new Error('ticker-data.csv not found. Please run generate_csv.js first.');
   }
 
   // FTP設定の確認

--- a/ticker-automation/src/generate_csv.js
+++ b/ticker-automation/src/generate_csv.js
@@ -1,0 +1,83 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const DATA_DIR = path.join(process.cwd(), 'data');
+const TICKER_JSON_FILE = path.join(DATA_DIR, 'ticker.json');
+const OUTPUT_CSV_FILE = path.join(DATA_DIR, 'ticker-data.csv');
+
+/**
+ * Convert ticker JSON data to CSV format
+ * CSV columns: id,title,url,category,status,priority,published_at,expires_at
+ */
+async function generateCSV() {
+  console.log('📊 Generating ticker-data.csv...');
+
+  // Read ticker.json
+  let tickerData;
+  try {
+    const jsonContent = await fs.readFile(TICKER_JSON_FILE, 'utf-8');
+    tickerData = JSON.parse(jsonContent);
+  } catch (error) {
+    throw new Error('ticker.json not found. Please run generate_ticker.js first.');
+  }
+
+  console.log(`  Loaded ${tickerData.length} items from ticker.json`);
+
+  // CSV Header
+  const header = 'id,title,url,category,status,priority,published_at,expires_at';
+
+  // Convert each item to CSV row
+  const rows = tickerData.map(item => {
+    // Map type to category
+    const category = item.type === 'pr' ? 'pr' : 'news';
+
+    // Escape CSV fields (handle commas, quotes, newlines)
+    const escapeCSV = (field) => {
+      if (field == null) return '';
+      const str = String(field);
+      // If field contains comma, quote, or newline, wrap in quotes and escape quotes
+      if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+        return `"${str.replace(/"/g, '""')}"`;
+      }
+      return str;
+    };
+
+    // Build CSV row
+    return [
+      escapeCSV(item.id || item.slot), // Use id if available, otherwise use slot as id
+      escapeCSV(item.title),
+      escapeCSV(item.url),
+      escapeCSV(category),
+      escapeCSV('active'), // All items in ticker.json are active
+      escapeCSV(item.type === 'pr' ? '1' : '2'), // PR has priority 1, news has priority 2
+      escapeCSV(item.published_at || ''),
+      escapeCSV(item.expires_at || '')
+    ].join(',');
+  });
+
+  // Combine header and rows
+  const csvContent = [header, ...rows].join('\n');
+
+  // Write CSV file
+  await fs.writeFile(OUTPUT_CSV_FILE, csvContent, 'utf-8');
+
+  console.log(`\n✅ Generated ticker-data.csv with ${tickerData.length} items`);
+  console.log(`  Output: ${OUTPUT_CSV_FILE}`);
+
+  return csvContent;
+}
+
+// Execute if run directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  generateCSV()
+    .then(() => {
+      console.log('✅ CSV generation completed');
+      process.exit(0);
+    })
+    .catch((error) => {
+      console.error('❌ Fatal error:', error);
+      process.exit(1);
+    });
+}
+
+export { generateCSV };


### PR DESCRIPTION
## Summary

This PR fixes the issue where ticker data was not being updated because only `ticker.json` was deployed, but a CSV file also needed to be generated and uploaded.

## Changes

1. **Created `generate_csv.js`** - Converts ticker.json to CSV format
2. **Modified `deploy.js`** - Uploads both JSON and CSV files
3. **Modified `run_finalize.sh`** - Added CSV generation step to pipeline

## Testing

- [ ] Verify CSV generation works locally
- [ ] Confirm both files are uploaded via FTP
- [ ] Check that Monday morning cron job updates CSV

Resolves #157

Generated with [Claude Code](https://claude.ai/code)