### PR TITLE
fix: ティッカーのインターバル重複バグ修正

### DIFF
--- a/assets/js/ticker.js
+++ b/assets/js/ticker.js
@@ -186,6 +186,12 @@ function createTickerItemHTML(item) {
 function startFadeAnimation() {
     if (!elements.tickerContent || tickerData.length === 0) return;
 
+    // 既存のインターバルをクリア（重複防止）
+    if (tickerInterval) {
+        clearInterval(tickerInterval);
+        tickerInterval = null;
+    }
+
     // 初期表示
     currentIndex = 0;
     showCurrentItem();


### PR DESCRIPTION
## 🐛 問題

ティッカーで偶数番目のニュースだけが表示される現象が発生。

## 🔧 修正内容

`startFadeAnimation()`が複数回呼ばれた際に、既存のインターバルをクリアせずに新しいインターバルを追加していた問題を修正。これにより、`setInterval`が重複して実行され、偶数番目のニュースのみが表示される現象が発生していた。

## ✅ 結果

- ページリロード時に10件全てが順番に表示される
- インターバルの重複が防止される

Fixes #158

🤖 Generated with [Claude Code](https://claude.ai/code)