### PR TITLE
feat: 食べたログの削除機能を追加（訪問単位の個別削除）

### DIFF
--- a/assets/css/logs.css
+++ b/assets/css/logs.css
@@ -164,6 +164,32 @@ body {
     border-radius: 4px;
 }
 
+/* 削除アイコン */
+.delete-visit-icon {
+    position: absolute;
+    top: 12px;
+    right: 48px;
+    background: none;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+    opacity: 0.6;
+    transition: opacity 0.2s, transform 0.2s;
+    padding: 8px;
+    line-height: 1;
+}
+
+.delete-visit-icon:hover {
+    opacity: 1;
+    transform: scale(1.1);
+}
+
+.delete-visit-icon:focus {
+    outline: 2px solid #dc3545;
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+
 .log-card h3 {
     font-size: 18px;
     color: #3A2A0A;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -636,6 +636,7 @@ function recordVisit() {
     console.log('記録中:', currentPlace.name);
 
     const log = {
+        visitId: generateUniqueId(), // 訪問ごとに一意のID
         id: currentPlace.place_id,
         name: currentPlace.name,
         address: currentPlace.vicinity,


### PR DESCRIPTION
## 概要

食べたログの削除機能を実装しました。訪問単位で個別に削除できるため、同じ店に複数回行った場合も特定の訪問のみ削除可能です。

## 変更内容

- 各訪問に一意のvisitIdを追加（後方互換性あり）
- ログカードに🗑️削除ボタンを追加
- 削除確認ダイアログを実装
- ヒートマップデータの自動更新
- カスタム地点と通常ログの両方に対応

Fixes #170

🤖 Generated with [Claude Code](https://claude.ai/code)