### PR TITLE
feat: 食べたログの削除機能を実装（レビュー改善版）

### DIFF
--- a/assets/css/logs.css
+++ b/assets/css/logs.css
@@ -138,6 +138,32 @@ body {
     box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
 }
 
+/* 削除アイコン */
+.delete-icon {
+    position: absolute;
+    top: 12px;
+    right: 48px; /* 編集アイコンの左側に配置 */
+    background: none;
+    border: none;
+    font-size: 20px;
+    cursor: pointer;
+    opacity: 0.6;
+    transition: opacity 0.2s, transform 0.2s;
+    padding: 8px;
+    line-height: 1;
+}
+
+.delete-icon:hover {
+    opacity: 1;
+    transform: scale(1.1);
+}
+
+.delete-icon:focus {
+    outline: 2px solid #DC143C;
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+
 /* 編集アイコン */
 .edit-icon {
     position: absolute;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -637,6 +637,7 @@ function recordVisit() {
 
     const log = {
         id: currentPlace.place_id,
+        visitId: generateUniqueId(), // 訪問ごとの一意ID
         name: currentPlace.name,
         address: currentPlace.vicinity,
         lat: currentPlace.geometry.location.lat(),


### PR DESCRIPTION
## 概要

訪問単位の削除機能を、レビュー指摘を反映して実装しました。

## レビュー改善点

1. **visitId重複対策（データ整合性）**
   - `filter()`の代わりに`findIndex()` + `splice()`を使用
   - 同じvisitIdが複数存在しても最初の1件のみを確実に削除

2. **パフォーマンス改善（O(n²) → O(n)）**
   - `updateHeatmapAfterDelete(deletedLog)`に削除対象を直接渡す
   - 全ログを走査せず、placeIdで直接ヒートマップデータにアクセス

## 実装内容

- 新規ログにvisitIdを自動付与
- 既存ログへの後方互換性
- 削除UI（🗑️ボタン）とCSS追加
- 削除確認ダイアログ（店名、日付、メニュー表示）
- ヒートマップの自動更新

Fixes #170

🤖 Generated with [Claude Code](https://claude.ai/code)