### PR TITLE
削除: 未使用のCSSクラスを削除

### DIFF
--- a/assets/css/logs.css
+++ b/assets/css/logs.css
@@ -245,44 +245,6 @@ body {
     font-weight: bold;
 }
 
-/* カスタム地点アクション */
-.log-item-actions {
-    display: flex;
-    gap: 8px;
-    margin-top: 12px;
-}
-
-.btn-edit-custom,
-.btn-delete-custom {
-    padding: 8px 16px;
-    border: none;
-    border-radius: 4px;
-    font-size: 14px;
-    font-weight: bold;
-    cursor: pointer;
-    transition: opacity 0.2s, transform 0.2s;
-}
-
-.btn-edit-custom {
-    background: #4CAF50;
-    color: white;
-}
-
-.btn-edit-custom:hover {
-    opacity: 0.9;
-    transform: translateY(-1px);
-}
-
-.btn-delete-custom {
-    background: #f44336;
-    color: white;
-}
-
-.btn-delete-custom:hover {
-    opacity: 0.9;
-    transform: translateY(-1px);
-}
-
 /* Empty State */
 .empty-state {
     text-align: center;


### PR DESCRIPTION
## 概要

カスタム地点のUI統一後、不要になったCSSクラスを削除しました。

## 変更内容

**場所**: `assets/css/logs.css:249-284`

以下の未使用CSSクラスを削除:
- `.log-item-actions` - 下部アクションボタンのコンテナ
- `.btn-edit-custom` - 編集ボタンのスタイル
- `.btn-delete-custom` - 削除ボタンのスタイル

## 背景

#173 でカスタム地点の編集・削除UIを右上アイコンに統一した際、下部ボタン用のCSSが不要になりました。

Fixes #173

---

Generated with [Claude Code](https://claude.ai/code)) • [View job run](https://github.com/masahito-hub/sekakare/actions/runs/19793584287) • [`claude/issue-173-20251130-0406`](https://github.com/masahito-hub/sekakare/tree/claude/issue-173-20251130-0406