### PR TITLE
feat: 検索機能改善 - サジェストドロップダウン＋検索結果一覧

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -64,6 +64,146 @@ body {
     box-shadow: 0 0 10px rgba(255, 140, 0, 0.3);
 }
 
+/* 検索サジェストドロップダウン */
+.search-suggestions {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: white;
+    border: 2px solid #ff8c00;
+    border-top: none;
+    border-radius: 0 0 15px 15px;
+    max-height: 300px;
+    overflow-y: auto;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    z-index: 1000;
+    display: none;
+}
+
+.search-suggestions.visible {
+    display: block;
+}
+
+.suggestion-item {
+    padding: 12px 15px;
+    cursor: pointer;
+    border-bottom: 1px solid #f0f0f0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    transition: background-color 0.2s;
+}
+
+.suggestion-item:hover {
+    background-color: #fff5ed;
+}
+
+.suggestion-item:last-child {
+    border-bottom: none;
+}
+
+.suggestion-icon {
+    font-size: 20px;
+    flex-shrink: 0;
+}
+
+.suggestion-content {
+    flex: 1;
+    min-width: 0;
+}
+
+.suggestion-name {
+    font-weight: 600;
+    color: #333;
+    margin-bottom: 2px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.suggestion-label {
+    font-size: 11px;
+    padding: 2px 8px;
+    border-radius: 10px;
+    display: inline-block;
+    margin-bottom: 2px;
+}
+
+.suggestion-label.places {
+    background: #ffc107;
+    color: #333;
+}
+
+.suggestion-label.curry-log {
+    background: #4caf50;
+    color: white;
+}
+
+.suggestion-label.custom-point {
+    background: #2196f3;
+    color: white;
+}
+
+.suggestion-info {
+    font-size: 12px;
+    color: #666;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* 検索結果一覧 */
+.search-results {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: white;
+    border: 2px solid #ff8c00;
+    border-top: none;
+    border-radius: 0 0 15px 15px;
+    max-height: 400px;
+    overflow-y: auto;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+    z-index: 1000;
+    display: none;
+}
+
+.search-results.visible {
+    display: block;
+}
+
+.search-result-item {
+    padding: 12px 15px;
+    cursor: pointer;
+    border-bottom: 1px solid #f0f0f0;
+    transition: background-color 0.2s;
+}
+
+.search-result-item:hover {
+    background-color: #fff5ed;
+}
+
+.search-result-item:last-child {
+    border-bottom: none;
+}
+
+.result-name {
+    font-weight: 600;
+    color: #333;
+    margin-bottom: 4px;
+}
+
+.result-info {
+    font-size: 12px;
+    color: #666;
+}
+
+.search-wrapper {
+    position: relative;
+}
+
 .log-section {
     padding: 15px;
     background: #fafafa;

--- a/index.html
+++ b/index.html
@@ -122,8 +122,12 @@
         <div id="map"></div>
 
         <div class="controls">
-            <input type="text" class="search-box" placeholder="🔍 店名で検索... (例: スープカレー GARAKU)" id="searchBox">
-            <small style="color: #666;">Enterキーで検索</small>
+            <div class="search-wrapper">
+                <input type="text" class="search-box" placeholder="🔍 店名で検索... (例: スープカレー GARAKU)" id="searchBox">
+                <div class="search-suggestions" id="searchSuggestions"></div>
+                <div class="search-results" id="searchResults"></div>
+            </div>
+            <small style="color: #666;">2文字以上でサジェスト表示 | Enterキーで検索結果一覧</small>
         </div>
 
         <div class="log-section">


### PR DESCRIPTION
## 概要
検索機能を大幅に改善し、サジェストドロップダウンと検索結果一覧を実装しました。

## 実装内容

### 1. サジェストドロップダウン
- 2文字以上入力でサジェスト表示
- 300ms debounce
- Places API + ローカルログ検索

### 2. 種別ラベル
- 🍛店舗(Places)
- ✅自分のログ(店舗)
- 📍自分のログ(カスタム)

### 3. 検索結果一覧
- Enterキーで上位5件表示
- 選択で地点へズーム
- 外クリックで閉じる

### 4. 検索対象拡張
- name/menu/memoの部分一致検索

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)