### PR TITLE
fix: PR #177レビュー指摘修正 - XSS対策・メモリリーク・エラーハンドリング

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1586,16 +1586,7 @@ function updateCustomPointPhotoPreview() {
     });
 
     preview.innerHTML = html;
-
-    // 削除ボタンのイベントリスナー
-    preview.querySelectorAll('.photo-delete-btn').forEach(btn => {
-        btn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            const photoId = btn.dataset.photoId;
-            customPointPhotos = customPointPhotos.filter(p => p.id !== photoId);
-            updateCustomPointPhotoPreview();
-        });
-    });
+    // イベントリスナーは親要素に委譲済み（setupCustomPointListeners内）
 }
 
 /**
@@ -1643,6 +1634,20 @@ function setupCustomPointListeners() {
             photoInput.click();
         });
         photoInput.addEventListener('change', handleCustomPointPhotoSelection);
+    }
+
+    // 写真削除ボタンのイベント委譲（メモリリーク防止）
+    const photoPreview = document.getElementById('customPointPhotoPreview');
+    if (photoPreview) {
+        photoPreview.addEventListener('click', (e) => {
+            // 削除ボタンがクリックされた場合のみ処理
+            if (e.target.classList.contains('photo-delete-btn')) {
+                e.stopPropagation();
+                const photoId = e.target.dataset.photoId;
+                customPointPhotos = customPointPhotos.filter(p => p.id !== photoId);
+                updateCustomPointPhotoPreview();
+            }
+        });
     }
 }
 


### PR DESCRIPTION
## 概要
PR #177 のレビュー指摘を修正

## 修正内容

### 1. XSS脆弱性対策 (ticker.js)
- item.typeにホワイトリスト検証を追加
- ALLOWED_TYPES = ['pr', 'news']で許可リストを定義
- 不正な値はデフォルト値'news'にフォールバック

### 2. メモリリーク対策 (app.js)
- 写真削除ボタンのイベントリスナーを委譲パターンに変更
- updateCustomPointPhotoPreview()での重複登録を防止
- 親要素(customPointPhotoPreview)で一度だけリスナー登録

### 3. エラーハンドリング改善 (ticker.js)
- ticker初期化エラー時にupdateDebugInfo()を呼び出し
- ユーザーに分かりやすいエラーメッセージを表示
- Places APIは既に適切なエラーハンドリング実装済み

Closes #178

🤖 Generated with [Claude Code](https://claude.ai/code)