### PR TITLE
feat: Add Twitter bot for automated tweet candidate generation (Phase 0)

### DIFF
--- a/twitter-bot/.env.example
+++ b/twitter-bot/.env.example
@@ -1,0 +1,8 @@
+# OpenAI API Key（既存のものを使用）
+OPENAI_API_KEY=sk-...
+
+# Slack Webhook URL（Twitter Bot専用チャンネル）
+SLACK_TWITTER_WEBHOOK_URL=https://hooks.slack.com/services/...
+
+# RSS Feeds（カレー関連ニュース）
+RSS_URLS="https://www.google.co.jp/alerts/feeds/...,https://www.google.co.jp/alerts/feeds/..."

--- a/twitter-bot/.gitignore
+++ b/twitter-bot/.gitignore
@@ -1,0 +1,12 @@
+# Environment variables
+.env
+
+# Logs
+logs/
+*.log
+
+# Node modules
+node_modules/
+
+# Dependency directories
+package-lock.json

--- a/twitter-bot/README.md
+++ b/twitter-bot/README.md
@@ -1,0 +1,231 @@
+# セカカレ Twitter Bot（Phase 0）
+
+セカカレ公式X用のツイートネタ自動生成ボットです。
+
+## 📋 概要
+
+**運用フロー**:
+- **火・木 10:00**: 自動実行（週2回）
+- カレー関連ニュースをRSSから取得し、LLMで整形（最大3件）
+- カレー豆知識をLLMで生成（3〜5件）
+- Slackの専用チャンネルに投稿候補を通知
+
+**Phase 0の機能**:
+1. **ニュース紹介ツイート**: RSSからカレー関連ニュースを取得しLLMで整形（最大3件）
+2. **カレー豆知識ツイート**: LLMでトリビアを生成（3〜5件）
+3. Slackの専用チャンネルに投稿
+
+## 🚀 セットアップ
+
+### 1. 前提条件
+
+- **Node.js**: v18以上
+- **npm**: 8以上
+- **環境**: VPS（cron実行）またはローカル
+
+### 2. 依存パッケージインストール
+
+```bash
+cd twitter-bot
+npm install
+```
+
+### 3. 環境変数設定
+
+```bash
+cp .env.example .env
+nano .env  # 以下の値を設定
+```
+
+**必須環境変数**:
+
+```bash
+# OpenAI API Key（既存のものを使用）
+OPENAI_API_KEY=sk-...
+
+# Slack Webhook URL（Twitter Bot専用チャンネル）
+SLACK_TWITTER_WEBHOOK_URL=https://hooks.slack.com/services/...
+
+# RSS Feeds（カレー関連ニュース）
+RSS_URLS="https://www.google.co.jp/alerts/feeds/.../...,https://www.google.co.jp/alerts/feeds/..."
+```
+
+### 4. 手動実行テスト
+
+```bash
+npm start
+```
+
+成功すると、Slackチャンネルにツイート候補が投稿されます。
+
+### 5. cron設定（VPS環境）
+
+```bash
+crontab -e
+```
+
+以下を追加:
+
+```cron
+# 火曜・木曜 10:00 - ツイート候補生成
+0 10 * * 2,4  cd /opt/sekakare/twitter-bot && node src/generate_tweet_candidates.js >> logs/generate_$(date +\%Y\%m\%d).log 2>&1
+```
+
+## 📁 ディレクトリ構造
+
+```
+twitter-bot/
+├── src/
+│   └── generate_tweet_candidates.js  # メインスクリプト
+├── logs/
+│   └── .gitkeep                      # ログ保存用
+├── .env                              # 環境変数（Git除外）
+├── .env.example                      # 環境変数テンプレート
+├── .gitignore                        # Git除外設定
+├── package.json                      # 依存パッケージ定義
+└── README.md                         # このファイル
+```
+
+## 🛠️ 技術スタック
+
+- **Node.js**: JavaScript実行環境
+- **OpenAI API**: gpt-3.5-turbo（ニュース整形・豆知識生成）
+- **rss-parser**: RSSフィード解析
+- **Slack Webhook**: 投稿候補の通知
+
+## 📝 機能詳細
+
+### 1. ニュース紹介ツイート
+
+RSSフィードからカレー関連ニュースを取得し、LLMで280文字以内のツイート形式に整形します。
+
+**処理フロー**:
+1. 複数のRSSフィードから最新ニュースを取得
+2. 日付順にソート
+3. 最大3件を選択
+4. 各ニュースをLLMで親しみやすいツイート文に整形
+
+**LLMプロンプトの特徴**:
+- カレー好きが興味を持つポイントを強調
+- 絵文字1〜2個使用
+- URLは末尾に配置
+- **NGルール**: 健康効果・ダイエット・病気改善には触れない（YMYL回避）
+
+### 2. カレー豆知識ツイート
+
+LLMでカレーに関する豆知識・トリビアを3〜5件生成します。
+
+**生成内容**:
+- カレーの歴史・文化・レシピに関する興味深い情報
+- 各280文字以内
+- 絵文字使用
+- **NGルール**: 健康効果・ダイエット・病気改善には触れない（YMYL回避）
+
+### 3. Slack通知
+
+生成されたツイート候補をSlackの専用チャンネルに投稿します。
+
+**通知内容**:
+- 生成日時
+- ニュースツイート候補（最大3件）
+- 豆知識ツイート候補（3〜5件）
+- 各候補の出典情報
+
+## ⚠️ NGルール（重要）
+
+Phase 0では以下の内容は**絶対に含めない**ようLLMに指示しています：
+
+- 健康効果（例: 「カレーで健康に」「免疫力アップ」）
+- ダイエット効果（例: 「痩せる」「カロリー制限」）
+- 病気改善（例: 「風邪予防」「認知症予防」）
+
+**理由**: YMYL（Your Money or Your Life）領域のコンテンツはGoogle検索で厳しく評価されるため、健康・医療に関する不確実な情報は避けます。
+
+## 🐛 トラブルシューティング
+
+### RSS取得失敗
+
+```bash
+# RSS URLの確認
+echo $RSS_URLS
+
+# 手動テスト
+node src/generate_tweet_candidates.js
+```
+
+ログファイル: `logs/generate_YYYY-MM-DD.log`
+
+### OpenAI API失敗
+
+```bash
+# API Keyの確認
+echo $OPENAI_API_KEY | cut -c1-10
+
+# クォータ・課金状況を確認
+# https://platform.openai.com/account/usage
+```
+
+**エラー例**:
+- `RateLimitError`: リクエスト制限超過 → 時間を空けて再実行
+- `AuthenticationError`: APIキーが無効 → 環境変数を再確認
+
+### Slack投稿失敗
+
+```bash
+# Webhook URLの確認
+echo $SLACK_TWITTER_WEBHOOK_URL
+
+# 手動テスト（curlで確認）
+curl -X POST $SLACK_TWITTER_WEBHOOK_URL \
+  -H 'Content-Type: application/json' \
+  -d '{"text":"Test message"}'
+```
+
+## 📊 ログファイル
+
+実行ログは `logs/` ディレクトリに日付別で保存されます。
+
+```bash
+# 最新ログの確認
+tail -f logs/generate_$(date +%Y-%m-%d).log
+
+# ログ一覧
+ls -lh logs/
+```
+
+**ログ内容**:
+- 処理開始・完了時刻
+- RSS取得結果
+- LLM生成結果
+- Slack投稿結果
+- エラー詳細（発生時）
+
+## 🔒 セキュリティ
+
+### 注意事項
+
+- `.env`ファイルは絶対にコミットしない
+- API Key、Webhook URLを含むファイルは`.gitignore`で除外済み
+- ログファイルも自動的に除外されます
+
+### 環境変数の管理
+
+- **開発環境**: `.env`ファイルで管理
+- **本番環境（VPS）**: 環境変数をシステムに設定するか、`.env`を安全な場所に配置
+
+## 🚧 今後の拡張（Phase 1以降）
+
+Phase 0では候補生成のみですが、今後以下の機能を追加予定：
+
+- **Phase 1**: Slackでのツイート承認フロー（リアクション方式）
+- **Phase 2**: X（Twitter）への自動投稿機能
+- **Phase 3**: ツイート効果測定・分析機能
+
+## 📄 ライセンス
+
+MIT License
+
+## 🔗 関連ドキュメント
+
+- [セカカレ README](../README.md)
+- [プロジェクト引き継ぎドキュメント](../HANDOVER.md)

--- a/twitter-bot/package.json
+++ b/twitter-bot/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "sekakare-twitter-bot",
+  "version": "1.0.0",
+  "description": "セカカレ公式X用ツイートネタ自動生成ボット（Phase 0）",
+  "type": "module",
+  "scripts": {
+    "start": "node src/generate_tweet_candidates.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "sekakare",
+    "twitter",
+    "bot",
+    "automation"
+  ],
+  "author": "masahito-hub",
+  "license": "MIT",
+  "dependencies": {
+    "rss-parser": "^3.13.0",
+    "openai": "^4.20.0",
+    "node-fetch": "^3.3.0",
+    "dotenv": "^16.3.1"
+  }
+}

--- a/twitter-bot/src/generate_tweet_candidates.js
+++ b/twitter-bot/src/generate_tweet_candidates.js
@@ -1,0 +1,367 @@
+import 'dotenv/config';
+import Parser from 'rss-parser';
+import OpenAI from 'openai';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// 環境変数の検証
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const SLACK_TWITTER_WEBHOOK_URL = process.env.SLACK_TWITTER_WEBHOOK_URL;
+const RSS_URLS = process.env.RSS_URLS?.split(',') || [];
+
+if (!OPENAI_API_KEY) {
+  console.error('❌ OPENAI_API_KEY が設定されていません');
+  process.exit(1);
+}
+
+if (!SLACK_TWITTER_WEBHOOK_URL) {
+  console.error('❌ SLACK_TWITTER_WEBHOOK_URL が設定されていません');
+  process.exit(1);
+}
+
+if (RSS_URLS.length === 0) {
+  console.error('❌ RSS_URLS が設定されていません');
+  process.exit(1);
+}
+
+// OpenAI API クライアント初期化
+const openai = new OpenAI({
+  apiKey: OPENAI_API_KEY,
+});
+
+// RSS パーサー初期化
+const parser = new Parser();
+
+// ログファイルパス
+const logDir = path.join(__dirname, '../logs');
+const logFile = path.join(logDir, `generate_${new Date().toISOString().split('T')[0]}.log`);
+
+// ログ記録関数
+function log(message) {
+  const timestamp = new Date().toISOString();
+  const logMessage = `[${timestamp}] ${message}\n`;
+  console.log(message);
+
+  if (!fs.existsSync(logDir)) {
+    fs.mkdirSync(logDir, { recursive: true });
+  }
+
+  fs.appendFileSync(logFile, logMessage);
+}
+
+/**
+ * RSSフィードからカレー関連ニュースを取得
+ * @returns {Promise<Array>} ニュース記事の配列
+ */
+async function fetchCurryNews() {
+  log('📰 RSSフィードからニュースを取得中...');
+
+  const allNews = [];
+
+  for (const rssUrl of RSS_URLS) {
+    try {
+      const feed = await parser.parseURL(rssUrl);
+      log(`✓ RSS取得成功: ${feed.title || 'Unknown Feed'}`);
+
+      feed.items.forEach(item => {
+        allNews.push({
+          title: item.title,
+          link: item.link,
+          pubDate: item.pubDate,
+          contentSnippet: item.contentSnippet || item.content || '',
+        });
+      });
+    } catch (error) {
+      log(`⚠️ RSS取得失敗: ${rssUrl} - ${error.message}`);
+    }
+  }
+
+  // 日付順にソート（新しい順）
+  allNews.sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate));
+
+  log(`📊 取得したニュース: ${allNews.length}件`);
+
+  // 最大3件まで
+  return allNews.slice(0, 3);
+}
+
+/**
+ * ニュース記事をLLMでツイート用に整形
+ * @param {Array} newsItems ニュース記事の配列
+ * @returns {Promise<Array>} 整形されたツイート候補の配列
+ */
+async function formatNewsForTweets(newsItems) {
+  log('🤖 LLMでニュースをツイート用に整形中...');
+
+  const tweets = [];
+
+  for (const item of newsItems) {
+    try {
+      const prompt = `あなたはカレー愛好家向けのX（旧Twitter）アカウント「セカカレ」の投稿を作成するアシスタントです。
+
+以下のニュース記事を、親しみやすく簡潔なツイート（280文字以内）に整形してください。
+
+【記事情報】
+タイトル: ${item.title}
+URL: ${item.link}
+内容: ${item.contentSnippet}
+
+【NGルール】
+- 健康効果・ダイエット・病気改善には絶対に触れない（YMYL回避）
+- 誇張表現は避ける
+- 不確実な情報は含めない
+
+【要件】
+- カレー好きが興味を持つポイントを強調
+- 絵文字を1〜2個使用
+- URLは末尾に配置
+- 280文字以内に収める
+
+ツイート文のみを出力してください。`;
+
+      const completion = await openai.chat.completions.create({
+        model: 'gpt-3.5-turbo',
+        messages: [
+          {
+            role: 'system',
+            content: 'あなたはカレー愛好家向けのSNS投稿を作成する専門家です。親しみやすく、簡潔で、正確な情報を提供します。',
+          },
+          {
+            role: 'user',
+            content: prompt,
+          },
+        ],
+        temperature: 0.7,
+        max_tokens: 300,
+      });
+
+      const tweetText = completion.choices[0].message.content.trim();
+      tweets.push({
+        type: 'news',
+        text: tweetText,
+        source: item.link,
+      });
+
+      log(`✓ ニュースツイート生成成功: ${item.title.substring(0, 30)}...`);
+    } catch (error) {
+      log(`⚠️ ニュースツイート生成失敗: ${error.message}`);
+    }
+  }
+
+  return tweets;
+}
+
+/**
+ * カレー豆知識をLLMで生成
+ * @returns {Promise<Array>} 豆知識ツイート候補の配列
+ */
+async function generateCurryTrivia() {
+  log('💡 LLMでカレー豆知識を生成中...');
+
+  const triviaCount = Math.floor(Math.random() * 3) + 3; // 3〜5件
+  const trivias = [];
+
+  try {
+    const prompt = `あなたはカレー愛好家向けのX（旧Twitter）アカウント「セカカレ」の投稿を作成するアシスタントです。
+
+カレーに関する豆知識・トリビアを${triviaCount}件生成してください。
+
+【NGルール】
+- 健康効果・ダイエット・病気改善には絶対に触れない（YMYL回避）
+- 誇張表現は避ける
+- 不確実な情報は含めない
+
+【要件】
+- 1件につき280文字以内
+- カレー好きが「へぇ〜」と思うような興味深い内容
+- 絵文字を1〜2個使用
+- 各豆知識は改行で区切る
+- 番号は付けずに「🍛」で始める
+
+出力形式:
+🍛 [豆知識1]
+🍛 [豆知識2]
+...`;
+
+    const completion = await openai.chat.completions.create({
+      model: 'gpt-3.5-turbo',
+      messages: [
+        {
+          role: 'system',
+          content: 'あなたはカレーの歴史・文化・レシピに精通した専門家です。正確で興味深い豆知識を提供します。',
+        },
+        {
+          role: 'user',
+          content: prompt,
+        },
+      ],
+      temperature: 0.8,
+      max_tokens: 1000,
+    });
+
+    const triviaText = completion.choices[0].message.content.trim();
+    const triviaItems = triviaText.split('\n').filter(line => line.startsWith('🍛'));
+
+    triviaItems.forEach(item => {
+      trivias.push({
+        type: 'trivia',
+        text: item.trim(),
+        source: 'AI生成',
+      });
+    });
+
+    log(`✓ 豆知識生成成功: ${trivias.length}件`);
+  } catch (error) {
+    log(`⚠️ 豆知識生成失敗: ${error.message}`);
+  }
+
+  return trivias;
+}
+
+/**
+ * ツイート候補をSlackに投稿
+ * @param {Array} newsTweets ニュースツイート候補
+ * @param {Array} triviaTweets 豆知識ツイート候補
+ */
+async function postToSlack(newsTweets, triviaTweets) {
+  log('📤 Slackに投稿中...');
+
+  const blocks = [
+    {
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: '🍛 セカカレ Twitter Bot - ツイート候補',
+        emoji: true,
+      },
+    },
+    {
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `*生成日時:* ${new Date().toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}`,
+      },
+    },
+    {
+      type: 'divider',
+    },
+  ];
+
+  // ニュースツイート
+  if (newsTweets.length > 0) {
+    blocks.push({
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: '📰 ニュース紹介ツイート',
+        emoji: true,
+      },
+    });
+
+    newsTweets.forEach((tweet, index) => {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*候補 ${index + 1}*\n${tweet.text}\n\n_出典:_ ${tweet.source}`,
+        },
+      });
+      blocks.push({ type: 'divider' });
+    });
+  }
+
+  // 豆知識ツイート
+  if (triviaTweets.length > 0) {
+    blocks.push({
+      type: 'header',
+      text: {
+        type: 'plain_text',
+        text: '💡 カレー豆知識ツイート',
+        emoji: true,
+      },
+    });
+
+    triviaTweets.forEach((tweet, index) => {
+      blocks.push({
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*候補 ${index + 1}*\n${tweet.text}`,
+        },
+      });
+      blocks.push({ type: 'divider' });
+    });
+  }
+
+  // フッター
+  blocks.push({
+    type: 'context',
+    elements: [
+      {
+        type: 'mrkdwn',
+        text: `合計: ニュース ${newsTweets.length}件 / 豆知識 ${triviaTweets.length}件`,
+      },
+    ],
+  });
+
+  const payload = {
+    blocks,
+  };
+
+  try {
+    const response = await fetch(SLACK_TWITTER_WEBHOOK_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    log('✓ Slack投稿成功');
+  } catch (error) {
+    log(`❌ Slack投稿失敗: ${error.message}`);
+    throw error;
+  }
+}
+
+/**
+ * メイン処理
+ */
+async function main() {
+  log('🚀 セカカレ Twitter Bot 起動');
+  log('=====================================');
+
+  try {
+    // 1. RSSからニュース取得
+    const newsItems = await fetchCurryNews();
+
+    // 2. ニュースをツイート用に整形
+    const newsTweets = await formatNewsForTweets(newsItems);
+
+    // 3. カレー豆知識を生成
+    const triviaTweets = await generateCurryTrivia();
+
+    // 4. Slackに投稿
+    await postToSlack(newsTweets, triviaTweets);
+
+    log('=====================================');
+    log('✅ すべての処理が正常に完了しました');
+    log(`📊 ニュース: ${newsTweets.length}件 / 豆知識: ${triviaTweets.length}件`);
+  } catch (error) {
+    log('❌ エラーが発生しました');
+    log(`エラー詳細: ${error.message}`);
+    log(error.stack);
+    process.exit(1);
+  }
+}
+
+// 実行
+main();


### PR DESCRIPTION
## 概要
Twitterボット機能(Phase 0)を追加しました。

## 機能
1. **ニュース紹介ツイート**: RSSからカレー関連ニュースを取得しLLMで整形（最大3件）
2. **カレー豆知識ツイート**: LLMでトリビアを生成（3〜5件）
3. Slackの専用チャンネルに投稿

## 技術スタック
- Node.js (ES modules)
- OpenAI API (gpt-3.5-turbo)
- rss-parser
- Slack Webhook

## NGルール
- 健康効果・ダイエット・病気改善には触れない（YMYL回避）

Resolves #185

🤖 Generated with [Claude Code](https://claude.ai/code)