### PR TITLE
feat: ニュースの重複排除を追加

### DIFF
--- a/twitter-bot/src/generate_tweet_candidates.js
+++ b/twitter-bot/src/generate_tweet_candidates.js
@@ -80,13 +80,22 @@ async function fetchCurryNews() {
     }
   }
 
-  // 日付順にソート（新しい順）
-  allNews.sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate));
+  // タイトルで重複排除
+  const seen = new Set();
+  const uniqueNews = allNews.filter(item => {
+    const key = item.title.replace(/<[^>]*>/g, '').trim();
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 
-  log(`📊 取得したニュース: ${allNews.length}件`);
+  // 日付順にソート（新しい順）
+  uniqueNews.sort((a, b) => new Date(b.pubDate) - new Date(a.pubDate));
+
+  log(`📊 取得したニュース: ${allNews.length}件（重複排除後: ${uniqueNews.length}件）`);
 
   // 最大3件まで
-  return allNews.slice(0, 3);
+  return uniqueNews.slice(0, 3);
 }
 
 /**


### PR DESCRIPTION
## 概要
複数のRSSフィードから同じニュースが取得される問題を修正。

## 変更内容
- タイトル（HTMLタグ除去・ trim済み）をキーとしてSetで重複チェック
- 重複排除後のニュース件数をログに出力

Fixes #189

----

Generated with [Claude Code](https://claude.ai/code)