### PR TITLE
fix: Twitter Botのニュース重複排除の正規化を強化

### DIFF
--- a/twitter-bot/src/generate_tweet_candidates.js
+++ b/twitter-bot/src/generate_tweet_candidates.js
@@ -80,10 +80,14 @@ async function fetchCurryNews() {
     }
   }
 
-  // タイトルで重複排除
+  // タイトルで重複排除（正規化を強化）
   const seen = new Set();
   const uniqueNews = allNews.filter(item => {
-    const key = item.title.replace(/<[^>]*>/g, '').trim();
+    const key = item.title
+      .replace(/<[^>]*>/g, '')  // HTMLタグ除去
+      .replace(/\s+/g, '')       // 空白を全て除去
+      .toLowerCase()             // 小文字化
+      .trim();
     if (seen.has(key)) return false;
     seen.add(key);
     return true;


### PR DESCRIPTION
Fixes #191

## 概要
ニュース重複排除の正規化を強化し、同じニュースが複数件出る問題を修正しました。

## 変更内容
HTMLタグ除去に加えて以下の正規化を追加:
- 空白文字の完全除去（全角/半角、連続空白含む）
- 小文字化による大文字小文字の違いを吸収

これにより、フォーマットの微妙な違いによる重複検出漏れを防ぎます。

---

Generated with [Claude Code](https://claude.ai/code)