### PR TITLE
Fix: PR #197 追加修正 - CSP, GA, escapeHtml

### DIFF
--- a/assets/js/ticker.js
+++ b/assets/js/ticker.js
@@ -120,7 +120,7 @@ async function fetchTickerData() {
                 slot: parseInt(item.slot) || 999,
                 id: escapeHtml(item.id),
                 type: safeType, // ホワイトリスト検証済み
-                title: escapeHtml(item.title),
+                title: item.title,
                 url: item.url, // URLはisValidUrlで検証
                 tag: escapeHtml(item.tag || ''), // newsの場合のタグ（event, trend等）
                 published_at: item.published_at,

--- a/logs.html
+++ b/logs.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     
     <!-- Content Security Policy -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https://maps.googleapis.com https://*.gstatic.com; script-src 'self' 'unsafe-inline' https://maps.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' https://maps.googleapis.com https://places.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https://maps.googleapis.com https://*.gstatic.com https://www.googletagmanager.com; script-src 'self' 'unsafe-inline' https://maps.googleapis.com https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' https://sekakare.life https://maps.googleapis.com https://places.googleapis.com https://www.google-analytics.com https://www.googletagmanager.com; font-src 'self' data: https://fonts.gstatic.com; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self';">
     
     <title>🍛 ログ - セカカレ</title>
     <meta name="description" content="あなたのカレー旅ログを時系列で振り返る">
@@ -38,6 +38,15 @@
 
     <!-- ハンバーガーメニューJS -->
     <script src="assets/js/menu.js"></script>
+
+    <!-- Google Analytics 4 -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-XXXXXXXXXX"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', Config.GA_ID);
+    </script>
 </head>
 <body>
     <!-- ヘッダー -->


### PR DESCRIPTION
## 修正内容

1. ✅ **logs.html**: CSPをindex.htmlからコピー (Google Analytics対応)
2. ✅ **logs.html**: Google Analytics 4トラッキングコード追加
3. ✅ **ticker.js**: titleのescapeHtml()を削除

## 手動対応が必要

- ❌ **deploy.yml**: GitHub Appの権限上、ワークフローファイルを修正できません。logs.htmlのGA_ID置換を追加する必要があります

Closes #198

---

Generated with [Claude Code](https://claude.ai/code)) | [View job run](https://github.com/masahito-hub/sekakare/actions/runs/20204099642