### PR TITLE
fix: Twitter bot news deduplication - remove source attributions

### DIFF
--- a/twitter-bot/src/generate_tweet_candidates.js
+++ b/twitter-bot/src/generate_tweet_candidates.js
@@ -84,9 +84,10 @@ async function fetchCurryNews() {
   const seen = new Set();
   const uniqueNews = allNews.filter(item => {
     const key = item.title
-      .replace(/<[^>]*>/g, '')  // HTMLタグ除去
-      .replace(/\s+/g, '')       // 空白を全て除去
-      .toLowerCase()             // 小文字化
+      .replace(/<[^>]*>/g, '')      // HTMLタグ除去
+      .replace(/[（(｜|].*$/g, '')  // ソース表記を除去
+      .replace(/\s+/g, '')           // 空白を全て除去
+      .toLowerCase()                 // 小文字化
       .trim();
     if (seen.has(key)) return false;
     seen.add(key);


### PR DESCRIPTION
ソース表記（共同通信、nippon.com等）が異なるだけの重複ニュースを正しく排除できるよう、タイトル正規化処理を改善しました。

Fixes #194

---

Generated with [Claude Code](https://claude.ai/code)