### PR TITLE
fix(#205): pin Maps JS API to v3.64 (temporary recovery)

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1367,7 +1367,7 @@ function setupEventListeners() {
 // 地図を読み込み
 function loadGoogleMaps() {
     const script = document.createElement('script');
-    script.src = `https://maps.googleapis.com/maps/api/js?key=${Config.API_KEY}&libraries=places,marker,visualization&callback=initMap`;
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${Config.API_KEY}&v=3.64&libraries=places,marker,visualization&callback=initMap`;
     script.async = true;
     script.onerror = () => {
         console.error('Google Maps APIの読み込みに失敗しました');


### PR DESCRIPTION
## 暫定復旧: Maps JS API を v3.64 に固定

Owner GO: `#205` comment 5235880032（2026-08-10 13:29 JST）

### 変更
`assets/js/app.js` L1370 の Maps JS 読み込みURLへ `&v=3.64` を追加（**1行のみ**）。

### 理由
Heatmap Layer が Maps JS API **v3.65 で廃止**され、バージョン未固定ロードにより自動配信された結果、初期化時のUncaught Errorでスクリプトが停止し**カレー店読み込みが全滅**していた（原因確定: #205 comment 5235340663）。

### スコープ厳守（混ぜていないもの）
- gtag placeholder defect（#202）
- Heatmap恒久対応（#206）
- Google Cloud設定 / API key
- その他リファクタ・依存更新

### rollback
`&v=3.64` の除去（revert 1コミット）。

### Post-deploy AC
1. 本番配信物が v=3.64 参照 2. Heatmap廃止uncaught error消失 3. カレー店読込/ピン復旧 4. ticker/地図/現在地/保存に新規回帰なし 5. 新規P1相当pageerrorなし
